### PR TITLE
Feature: Colour Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-build/*
-build*
+build/
 rom/*
 lib/*
 doxygen/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+echo "Cleaning Project & Building RP2040"
+rm -rf build/rp2040
+cmake -B build/rp2040 -DCMAKE_TOOLCHAIN_FILE=./toolchain-pico.cmake .
+cmake --build build/rp2040
+echo "RP2040 Picowalker-core.a Complete!"
+
+echo "Cleaning Project & Building RP2350"
+rm -rf build/rp2350
+cmake -B build/rp2350 -DCMAKE_TOOLCHAIN_FILE=./toolchain-pico2.cmake .
+cmake --build build/rp2350
+echo "RP2350 Picowalker-core.a Complete!"

--- a/src/apps/app_battle.c
+++ b/src/apps/app_battle.c
@@ -590,12 +590,33 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
 
 void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
 
-    pw_img_t our_sprite   = {.width=32, .height=24, .size=192, .data=decompression_buf};
-    pw_img_t their_sprite = {.width=32, .height=24, .size=192, .data=decompression_buf+192};
+    pw_eeprom_addr_t our_addr;
+    pw_img_t our_sprite = {
+        .width=32,
+        .height=24,
+        .data=decompression_buf,
+        .size=192,
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
+    };
+    pw_pokemon_index_to_small_sprite(PIDX_WALKING, our_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &our_addr);
+    our_sprite.lookup_table.addr = our_addr;
 
-    pw_pokemon_index_to_small_sprite(s->battle.chosen_pokemon+1, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET);
-
-    pw_pokemon_index_to_small_sprite(PIDX_WALKING, our_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET);
+    pw_eeprom_addr_t their_addr;
+    pw_img_t their_sprite = {
+        .width=32,
+        .height=24,
+        .data=decompression_buf+192,
+        .size=192,
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
+    };
+    pw_pokemon_index_to_small_sprite(s->battle.chosen_pokemon+1, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &their_addr);
+    their_sprite.lookup_table.addr = their_addr;
 
     switch(s->battle.current_substate) {
     case BATTLE_OPENING: {
@@ -612,7 +633,16 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
             PW_SCREEN_BLACK
         );
 
-        pw_img_t health_bar = {.width=8, .height=8, .data=eeprom_buf, .size=16};
+        pw_img_t health_bar = {
+            .width=8,
+            .height=8,
+            .data=eeprom_buf,
+            .size=16,
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP,
+                .use_alt=true
+            }
+        };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP, eeprom_buf, PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP);
 
         int8_t health = (s->battle.current_hp&THEIR_HP_MASK) >> THEIR_HP_OFFSET;
@@ -633,7 +663,8 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
             0, PW_SCREEN_HEIGHT-32,
             96, 32,
             PW_EEPROM_ADDR_TEXT_RADAR_ACTION,
-            PW_EEPROM_SIZE_TEXT_RADAR_ACTION
+            PW_EEPROM_SIZE_TEXT_RADAR_ACTION,
+            false
         );
         break;
     }
@@ -718,7 +749,8 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
             THEIR_NORMAL_X, THEIR_NORMAL_Y,
             32, 24,
             PW_EEPROM_ADDR_IMG_RADAR_APPEAR_CLOUD,
-            PW_EEPROM_SIZE_IMG_RADAR_APPEAR_CLOUD
+            PW_EEPROM_SIZE_IMG_RADAR_APPEAR_CLOUD,
+            true
         );
         break;
     }
@@ -732,7 +764,8 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
             WOBBLE_INITIAL_Y, WOBBLE_INITIAL_Y,
             8, 8,
             PW_EEPROM_ADDR_IMG_BALL,
-            PW_EEPROM_SIZE_IMG_BALL
+            PW_EEPROM_SIZE_IMG_BALL,
+            true
         );
         break;
     }
@@ -762,7 +795,16 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
 
 
 static void draw_our_hp_bar(pw_img_t *battle_buffer, uint8_t hp) {
-    pw_img_t hp_sprite = {.width=8, .height=8, .data=decompression_buf, .size=PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP};
+     pw_img_t hp_sprite = {
+        .width=8,
+        .height=8,
+        .data=decompression_buf,
+        .size=PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP,
+        .lookup_table = {
+            .addr=PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP,
+            .use_alt=true
+        }
+    };
     pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP, hp_sprite.data, PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP);
 
     for(uint8_t i = 0; i < hp; i++) {
@@ -772,7 +814,16 @@ static void draw_our_hp_bar(pw_img_t *battle_buffer, uint8_t hp) {
 }
 
 static void draw_their_hp_bar(pw_img_t *battle_buffer, uint8_t hp) {
-    pw_img_t hp_sprite = {.width=8, .height=8, .data=decompression_buf, .size=PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP};
+    pw_img_t hp_sprite = {
+        .width=8,
+        .height=8,
+        .data=decompression_buf,
+        .size=PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP,
+        .lookup_table = {
+            .addr=PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP,
+            .use_alt=true
+        }
+    };
     pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP, hp_sprite.data, PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP);
 
     for(uint8_t i = 0; i < hp; i++) {
@@ -810,9 +861,27 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         return;
     }
 
-    pw_img_t our_sprite   = {.width=32, .height=24, .size=192, .data=eeprom_buf};
+    pw_img_t our_sprite   = {
+        .width=32,
+        .height=24,
+        .data=eeprom_buf,
+        .size=192,
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
+    };
     //pw_img_t their_sprite = {.width=32, .height=24, .size=192, .data=decompression_buf};
-    pw_img_t their_sprite = {.width=32, .height=24, .size=192, .data=eeprom_buf+192};
+    pw_img_t their_sprite = {
+        .width=32,
+        .height=24,
+        .data=eeprom_buf+192,
+        .size=192,
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
+    };
     pw_img_t battle_buffer;
     pw_screen_get_blank_image(&battle_buffer, 96, 32);
     if(battle_buffer.size == 0) {
@@ -820,9 +889,11 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         return;
     }
 
-    pw_pokemon_index_to_small_sprite(s->battle.chosen_pokemon+1, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET);
-
-    pw_pokemon_index_to_small_sprite(PIDX_WALKING, our_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET);
+    pw_eeprom_addr_t our_addr;
+    pw_pokemon_index_to_small_sprite(PIDX_WALKING, our_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &our_addr);
+    
+    pw_eeprom_addr_t their_addr;
+    pw_pokemon_index_to_small_sprite(s->battle.chosen_pokemon+1, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &their_addr);
 
     switch(s->battle.current_substate) {
     case BATTLE_OPENING: {
@@ -856,12 +927,30 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
 
         if(s->battle.anim_frame == (ATTACK_ANIM_LENGTH+1)/2) {
             if(their_action == ACTION_SPECIAL) {
-                pw_img_t crit_hit = {.width = 16, .height = 32, .data=decompression_buf, .size=PW_EEPROM_SIZE_IMG_RADAR_CRITICAL_HIT};
+                pw_img_t crit_hit = {
+                    .width = 16,
+                    .height = 32,
+                    .data=decompression_buf,
+                    .size=PW_EEPROM_SIZE_IMG_RADAR_CRITICAL_HIT,
+                    .lookup_table = {
+                        .addr=PW_EEPROM_ADDR_IMG_RADAR_CRITICAL_HIT,
+                        .use_alt=true
+                    }
+                };
                 pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_CRITICAL_HIT, crit_hit.data, PW_EEPROM_SIZE_IMG_RADAR_CRITICAL_HIT);
                 pw_screen_overlay_img(&battle_buffer, &crit_hit, (PW_SCREEN_WIDTH-16)/2, 0);
 
             } else if(their_action != ACTION_EVADE) {
-                pw_img_t normal_hit = {.width = 16, .height = 32, .data=decompression_buf, .size=PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT};
+                pw_img_t normal_hit = {
+                    .width = 16,
+                    .height = 32,
+                    .data=decompression_buf,
+                    .size=PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT,
+                    .lookup_table = {
+                        .addr=PW_EEPROM_ADDR_IMG_RADAR_ATTACK_HIT,
+                        .use_alt=true
+                    }
+                };
                 pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_ATTACK_HIT, normal_hit.data, PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT);
                 pw_screen_overlay_img(&battle_buffer, &normal_hit, (PW_SCREEN_WIDTH-16)/2, 0);
             }
@@ -882,7 +971,16 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
 
         if(s->battle.anim_frame == (ATTACK_ANIM_LENGTH+1)/2) {
             if(our_action != ACTION_EVADE) {
-                pw_img_t normal_hit = {.width = 16, .height = 32, .data=decompression_buf, .size=PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT};
+                pw_img_t normal_hit = {
+                    .width = 16,
+                    .height = 32,
+                    .data=decompression_buf,
+                    .size=PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT,
+                    .lookup_table = {
+                        .addr=PW_EEPROM_ADDR_IMG_RADAR_ATTACK_HIT,
+                        .use_alt=true
+                    }
+                };
                 pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_ATTACK_HIT, normal_hit.data, PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT);
                 pw_screen_overlay_img(&battle_buffer, &normal_hit, (PW_SCREEN_WIDTH-16)/2, 0);
             }
@@ -911,7 +1009,16 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         pw_screen_overlay_img(&battle_buffer, &our_sprite, THEIR_ATTACK_XS[0][0], 8);
         pw_screen_overlay_img(&battle_buffer, &their_sprite, THEIR_ATTACK_XS[1][0], 0);
 
-        pw_img_t ball = {.width=8, .height=8, .size=16, .data=decompression_buf};
+        pw_img_t ball = {
+            .width=8, 
+            .height=8,
+            .data=decompression_buf,
+            .size=16, 
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_IMG_BALL,
+                .use_alt=true
+            }
+        };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_BALL, ball.data, PW_EEPROM_SIZE_IMG_BALL);
         pw_screen_overlay_img(&battle_buffer, &ball, POKEBALL_THROW_XS[s->battle.anim_frame], POKEBALL_THROW_YS[s->battle.anim_frame]);
 
@@ -948,7 +1055,16 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
 
         pw_screen_overlay_img(&battle_buffer, &our_sprite, THEIR_ATTACK_XS[0][0], 8);
 
-        pw_img_t ball = {.width=8, .height=8, .size=16, .data=decompression_buf};
+        pw_img_t ball = {
+            .width=8,
+            .height=8,
+            .data=decompression_buf,
+            .size=16,
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_IMG_BALL,
+                .use_alt=true
+            }
+        };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_BALL, ball.data, PW_EEPROM_SIZE_IMG_BALL);
         pw_screen_overlay_img(&battle_buffer, &ball, x, 16);
 
@@ -967,11 +1083,29 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
     case BATTLE_CATCH_STARS: {
         pw_screen_overlay_img(&battle_buffer, &our_sprite, THEIR_ATTACK_XS[0][0], 8);
 
-        pw_img_t star = {.width=8, .height=8, .size=16, .data=decompression_buf};
+        pw_img_t star = {
+            .width=8,
+            .height=8,
+            .data=decompression_buf,
+            .size=16,
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_IMG_RADAR_CATCH_EFFECT,
+                .use_alt=true
+            }
+        };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_CATCH_EFFECT, star.data, PW_EEPROM_SIZE_IMG_RADAR_CATCH_EFFECT);
         pw_screen_overlay_img(&battle_buffer, &star, THEIR_NORMAL_X, THEIR_NORMAL_Y+8-s->battle.anim_frame);
 
-        pw_img_t ball = {.width=8, .height=8, .size=16, .data=decompression_buf};
+        pw_img_t ball = {
+            .width=8,
+            .height=8,
+            .data=decompression_buf,
+            .size=16,
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_IMG_BALL,
+                .use_alt=true
+            }
+        };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_BALL, ball.data, PW_EEPROM_SIZE_IMG_BALL);
         pw_screen_overlay_img(&battle_buffer, &ball, THEIR_NORMAL_X+8, 16);
 

--- a/src/apps/app_comms.c
+++ b/src/apps/app_comms.c
@@ -269,19 +269,22 @@ void pw_comms_init_display(pw_state_t *s, const screen_flags_t *sf) {
                 (PW_SCREEN_WIDTH-32)/2, PW_SCREEN_HEIGHT-32-16,
                 32, 32,
                 PW_EEPROM_ADDR_IMG_POKEWALKER_BIG,
-                PW_EEPROM_SIZE_IMG_POKEWALKER_BIG
+                PW_EEPROM_SIZE_IMG_POKEWALKER_BIG,
+                true
             );
             pw_screen_draw_from_eeprom(
                 (PW_SCREEN_WIDTH-8)/2, 0,
                 8, 16,
                 PW_EEPROM_ADDR_IMG_IR_ARCS,
-                PW_EEPROM_SIZE_IMG_IR_ARCS
+                PW_EEPROM_SIZE_IMG_IR_ARCS,
+                true
             );
             pw_screen_draw_from_eeprom(
                 0, PW_SCREEN_HEIGHT-16,
                 96, 16,
                 PW_EEPROM_ADDR_TEXT_CONNECTING,
-                PW_EEPROM_SIZE_TEXT_CONNECTING
+                PW_EEPROM_SIZE_TEXT_CONNECTING,
+                false
             );
             pw_screen_draw_text_box(0, PW_SCREEN_HEIGHT-16, PW_SCREEN_WIDTH, 16, PW_SCREEN_BLACK);
             break;
@@ -332,7 +335,8 @@ void pw_comms_init_display(pw_state_t *s, const screen_flags_t *sf) {
                 (PW_SCREEN_WIDTH-64)/2, 8,
                 64, 48,
                 PW_EEPROM_ADDR_IMG_POKEMON_LARGE_ANIMATED + ((sf->frame & ANIM_FRAME_DOUBLE_TIME)*PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME),
-                PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME
+                PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME,
+                true
             );
             pw_screen_fill_area(0, 0, PW_SCREEN_WIDTH, 8, PW_SCREEN_BLACK);
             pw_screen_fill_area(0, PW_SCREEN_HEIGHT-8, PW_SCREEN_WIDTH, 8, PW_SCREEN_BLACK);
@@ -347,19 +351,44 @@ void pw_comms_init_display(pw_state_t *s, const screen_flags_t *sf) {
             break;
         }
         case COMM_SUBSTATE_FIRST_IDLE: {
-            pw_img_t img = {.height=32, .width=32, .size=256, .data=eeprom_buf};
+            pw_img_t img = {
+                .width=32, 
+                .height=32, 
+                .data=eeprom_buf,
+                .size=256, 
+                .lookup_table = {
+                    .addr=0, // PW_EEPROM_ADDR_IMG_POKEWALKER_BIG, // FLASH_IMG_POKEWALKER
+                    .use_alt=true
+                }
+            };
             pw_flash_read(PW_FLASH_IMG_POKEWALKER, img.data);
             pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-32)/2, (PW_SCREEN_HEIGHT-32)/2);
 
-            img.width = 16;
-            img.height = 8;
-            img.size = 0x20;
-            pw_flash_read(PW_FLASH_IMG_FACE_NEUTRAL, img.data);
-            pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-16)/2, (PW_SCREEN_HEIGHT-8)/2);
+            pw_img_t face = {
+                .width=16, 
+                .height=8, 
+                .data=eeprom_buf,
+                .size=32, 
+                .lookup_table = {
+                    .addr=-1,
+                    .use_alt=false
+                }
+            };
+            pw_flash_read(PW_FLASH_IMG_FACE_NEUTRAL, face.data);
+            pw_screen_draw_img(&face, (PW_SCREEN_WIDTH-16)/2, (PW_SCREEN_HEIGHT-8)/2);
             break;
         }
         case COMM_SUBSTATE_FIRST_SLAVE_PERFORM_REQUEST: {
-            pw_img_t face = {.width=16, .height=8, .size=32, .data=eeprom_buf};
+            pw_img_t face = {
+                .width=16,
+                .height=8,
+                .data=eeprom_buf,
+                .size=32,
+                .lookup_table = {
+                    .addr=-1, // FLASH_IMG_FACE_HAPPY,
+                    .use_alt=false
+                }
+            };
             pw_flash_read(PW_FLASH_IMG_FACE_HAPPY, face.data);
             pw_screen_draw_img(&face, (PW_SCREEN_WIDTH-16)/2, (PW_SCREEN_HEIGHT-8)/2);
             pw_screen_clear_area((PW_SCREEN_WIDTH-8)/2, 48, 8, 8);
@@ -399,7 +428,8 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                     (PW_SCREEN_WIDTH-8)/2, 0,
                     8, 16,
                     PW_EEPROM_ADDR_IMG_IR_ARCS,
-                    PW_EEPROM_SIZE_IMG_IR_ARCS
+                    PW_EEPROM_SIZE_IMG_IR_ARCS,
+                    true
                 );
             } else {
                 pw_screen_clear_area((PW_SCREEN_WIDTH-8)/2, 0, 8, 16);
@@ -438,7 +468,8 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                         (PW_SCREEN_WIDTH-32)/2, PW_SCREEN_HEIGHT-32-16,
                         32, 24,
                         PW_EEPROM_ADDR_IMG_RADAR_APPEAR_CLOUD,
-                        PW_EEPROM_SIZE_IMG_RADAR_APPEAR_CLOUD
+                        PW_EEPROM_SIZE_IMG_RADAR_APPEAR_CLOUD,
+                        true
                     );
                     break;
                 }
@@ -447,7 +478,8 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                         (PW_SCREEN_WIDTH-64)/2, 8,
                         64, 48,
                         PW_EEPROM_ADDR_IMG_POKEMON_LARGE_ANIMATED,
-                        PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED
+                        PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED,
+                        true
                     );
                     //pw_screen_fill_area(0, 0, PW_SCREEN_WIDTH, 8, PW_SCREEN_BLACK);
                     //pw_screen_fill_area(0, PW_SCREEN_HEIGHT-8, PW_SCREEN_WIDTH, 8, PW_SCREEN_BLACK);
@@ -458,7 +490,8 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                         (PW_SCREEN_WIDTH-64)/2, 8,
                         64, 48,
                         PW_EEPROM_ADDR_IMG_POKEMON_LARGE_ANIMATED+PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME,
-                        PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED
+                        PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED,
+                        true
                     );
                     //pw_screen_fill_area(0, 0, PW_SCREEN_WIDTH, 8, PW_SCREEN_BLACK);
                     //pw_screen_fill_area(0, PW_SCREEN_HEIGHT-8, PW_SCREEN_WIDTH, 8, PW_SCREEN_BLACK);
@@ -470,7 +503,8 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                         0, PW_SCREEN_HEIGHT-32,
                         80, 16,
                         PW_EEPROM_ADDR_TEXT_POKEMON_NAME,
-                        PW_EEPROM_SIZE_TEXT_POKEMON_NAME
+                        PW_EEPROM_SIZE_TEXT_POKEMON_NAME,
+                        false
                     );
                     pw_screen_draw_message(PW_SCREEN_HEIGHT-16, 13, 16);
                     pw_screen_draw_text_box(0, PW_SCREEN_HEIGHT-32, PW_SCREEN_WIDTH, 32, PW_SCREEN_BLACK);
@@ -489,7 +523,8 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                         (PW_SCREEN_WIDTH-32)/2, 8,
                         32, 24,
                         PW_EEPROM_ADDR_IMG_POKEMON_SMALL_ANIMATED+((sf->frame & ANIM_FRAME_DOUBLE_TIME)*PW_EEPROM_SIZE_IMG_POKEMON_SMALL_ANIMATED_FRAME),
-                        PW_EEPROM_SIZE_IMG_POKEMON_SMALL_ANIMATED
+                        PW_EEPROM_SIZE_IMG_POKEMON_SMALL_ANIMATED,
+                        true
                     );
                     break;
                 }
@@ -519,7 +554,8 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                         (PW_SCREEN_WIDTH-64)/2, 8,
                         64, 48,
                         PW_EEPROM_ADDR_IMG_POKEMON_LARGE_ANIMATED + ((sf->frame & ANIM_FRAME_DOUBLE_TIME)*PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME),
-                        PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME
+                        PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME,
+                        true
                     );
                     break;
                 }
@@ -533,7 +569,8 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                         (PW_SCREEN_WIDTH-32)/2, PW_SCREEN_HEIGHT-32-16,
                         32, 24,
                         PW_EEPROM_ADDR_IMG_RADAR_APPEAR_CLOUD,
-                        PW_EEPROM_SIZE_IMG_RADAR_APPEAR_CLOUD
+                        PW_EEPROM_SIZE_IMG_RADAR_APPEAR_CLOUD,
+                        true
                     );
                     break;
                 }
@@ -551,7 +588,8 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                         0, PW_SCREEN_HEIGHT-32,
                         80, 16,
                         PW_EEPROM_ADDR_TEXT_POKEMON_NAME,
-                        PW_EEPROM_SIZE_TEXT_POKEMON_NAME
+                        PW_EEPROM_SIZE_TEXT_POKEMON_NAME,
+                        false
                     );
                     pw_screen_draw_message(PW_SCREEN_HEIGHT-16, 14, 16); // "has left"
                     pw_screen_draw_text_box(0, PW_SCREEN_HEIGHT-32, PW_SCREEN_WIDTH, 32, PW_SCREEN_BLACK);
@@ -572,7 +610,16 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 break;
             }
 
-            pw_img_t img = {.width=8, .height=8, .size=16, .data=eeprom_buf};
+            pw_img_t img = {
+                .width=8,
+                .height=8,
+                .data=eeprom_buf,
+                .size=16,
+                .lookup_table = {
+                    .addr=PW_FLASH_IMG_UP_ARROW,
+                    .use_alt=false
+                }
+            };
             if(sf->frame&ANIM_FRAME_NORMAL_TIME) {
                 pw_flash_read(PW_FLASH_IMG_UP_ARROW, img.data);
                 pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-8)/2, 48);
@@ -588,7 +635,16 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
         }
         case COMM_SUBSTATE_FIRST_TIMEOUT: {
             pw_screen_clear_area((PW_SCREEN_WIDTH-8)/2, 0, 8, 8);
-            pw_img_t face = {.width=16, .height=8, .size=32, .data=eeprom_buf};
+            pw_img_t face = {
+                .width=16,
+                .height=8,
+                .data=eeprom_buf,
+                .size=32,
+                .lookup_table = {
+                    .addr=PW_FLASH_IMG_FACE_SAD,
+                    .use_alt=false
+                }
+            };
             pw_flash_read(PW_FLASH_IMG_FACE_SAD, face.data);
             pw_screen_draw_img(&face, (PW_SCREEN_WIDTH-16)/2, (PW_SCREEN_HEIGHT-8)/2);
             s->comms.timer--;
@@ -601,7 +657,16 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
             }
 
             if(sf->frame&ANIM_FRAME_NORMAL_TIME) {
-                pw_img_t img = {.width=8, .height=8, .size=16, .data=eeprom_buf};
+                pw_img_t img = {
+                    .width=8,
+                    .height=8,
+                    .data=eeprom_buf,
+                    .size=16,
+                    .lookup_table = {
+                        .addr=PW_FLASH_IMG_IR_ACTIVE,
+                        .use_alt=false
+                    }
+                };
                 pw_flash_read(PW_FLASH_IMG_IR_ACTIVE, img.data);
                 pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-8)/2, 0);
             } else {

--- a/src/apps/app_dowsing.c
+++ b/src/apps/app_dowsing.c
@@ -132,7 +132,16 @@ void pw_dowsing_init(pw_state_t *s, const screen_flags_t *sf) {
 }
 
 void pw_dowsing_init_display(pw_state_t *s, const screen_flags_t *sf) {
-    pw_img_t grass = {.data=img_buf, .width=16, .height=16, .size=PW_EEPROM_SIZE_IMG_DOWSING_BUSH_DARK};
+    pw_img_t grass = {
+        .width=16, 
+        .height=16, 
+        .data=img_buf,
+        .size=PW_EEPROM_SIZE_IMG_DOWSING_BUSH_DARK,
+        .lookup_table = {
+            .addr=PW_EEPROM_ADDR_IMG_DOWSING_BUSH_DARK,
+            .use_alt=true
+        }
+    };
     pw_eeprom_read(
         PW_EEPROM_ADDR_IMG_DOWSING_BUSH_DARK,
         grass.data,
@@ -147,14 +156,16 @@ void pw_dowsing_init_display(pw_state_t *s, const screen_flags_t *sf) {
                     16*i+2, PW_SCREEN_HEIGHT-16-8,
                     8, 8,
                     PW_EEPROM_ADDR_IMG_ARROW_UP_NORMAL,
-                    PW_EEPROM_SIZE_IMG_ARROW
+                    PW_EEPROM_SIZE_IMG_ARROW,
+                    false
                 );
             } else {
                 pw_screen_draw_from_eeprom(
                     16*i+2, PW_SCREEN_HEIGHT-16-8,
                     8, 8,
                     PW_EEPROM_ADDR_IMG_ARROW_UP_OFFSET,
-                    PW_EEPROM_SIZE_IMG_ARROW
+                    PW_EEPROM_SIZE_IMG_ARROW,
+                    false
                 );
             }
         }
@@ -173,21 +184,24 @@ void pw_dowsing_init_display(pw_state_t *s, const screen_flags_t *sf) {
         0, 0,
         32, 24,
         PW_EEPROM_ADDR_IMG_ROUTE_LARGE,
-        PW_EEPROM_SIZE_IMG_ROUTE_LARGE
+        PW_EEPROM_SIZE_IMG_ROUTE_LARGE,
+        true
     );
 
     pw_screen_draw_from_eeprom(
         36, 0,
         32, 16,
         PW_EEPROM_ADDR_TEXT_LEFT,
-        PW_EEPROM_SIZE_TEXT_LEFT
+        PW_EEPROM_SIZE_TEXT_LEFT,
+        false
     );
 
     pw_screen_draw_from_eeprom(
         76, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_DIGITS + PW_EEPROM_SIZE_IMG_CHAR*s->dowsing.choices_remaining,
-        PW_EEPROM_SIZE_IMG_CHAR
+        PW_EEPROM_SIZE_IMG_CHAR,
+        false
     );
 
 }
@@ -219,7 +233,8 @@ static void choosing_draw_update(pw_state_t *s, const screen_flags_t *sf) {
         cx, PW_SCREEN_HEIGHT-16-8,
         8, 8,
         addr,
-        PW_EEPROM_SIZE_IMG_ARROW
+        PW_EEPROM_SIZE_IMG_ARROW,
+        false
     );
 
 }
@@ -231,7 +246,8 @@ static void selected_draw_update(pw_state_t *s, const screen_flags_t *sf) {
         16*s->dowsing.current_cursor, y,
         16, 16,
         PW_EEPROM_ADDR_IMG_DOWSING_BUSH_DARK,
-        PW_EEPROM_SIZE_IMG_DOWSING_BUSH_DARK
+        PW_EEPROM_SIZE_IMG_DOWSING_BUSH_DARK,
+        true
     );
     y = (sf->frame&ANIM_FRAME_NORMAL_TIME)?BUSH_HEIGHT:BUSH_HEIGHT+16-2;
     pw_screen_clear_area(16*s->dowsing.current_cursor, y, 16, 2);
@@ -248,14 +264,16 @@ static void replace_item_draw_update(pw_state_t *s, const screen_flags_t *sf) {
             20+s->dowsing.current_cursor*(8+16), PW_SCREEN_HEIGHT-32,
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_UP_NORMAL,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
     } else {
         pw_screen_draw_from_eeprom(
             20+s->dowsing.current_cursor*(8+16), PW_SCREEN_HEIGHT-32,
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_UP_OFFSET,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
     }
 
@@ -294,14 +312,16 @@ static void check_guess_draw_init(pw_state_t *s, const screen_flags_t *sf) {
         16*s->dowsing.current_cursor, BUSH_HEIGHT,
         16, 16,
         PW_EEPROM_ADDR_IMG_DOWSING_BUSH_LIGHT,
-        PW_EEPROM_SIZE_IMG_DOWSING_BUSH_LIGHT
+        PW_EEPROM_SIZE_IMG_DOWSING_BUSH_LIGHT,
+        true
     );
 
     pw_screen_draw_from_eeprom(
         76, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_DIGITS + PW_EEPROM_SIZE_IMG_CHAR*s->dowsing.choices_remaining,
-        PW_EEPROM_SIZE_IMG_CHAR
+        PW_EEPROM_SIZE_IMG_CHAR,
+        false
     );
     s->dowsing.current_substate = s->dowsing.current_substate;
 
@@ -447,7 +467,16 @@ void pw_dowsing_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *s
         for(avail = 0; (avail<3) && (inv[avail].le_item != 0); avail++);
 
         // Draw "Item found" text
-        pw_img_t item_found_img = {.width=PW_SCREEN_WIDTH, .height=32, .data=eeprom_buf, .size=2*PW_EEPROM_SIZE_TEXT_FOUND};
+        pw_img_t item_found_img = {
+            .width=PW_SCREEN_WIDTH,
+            .height=32,
+            .data=eeprom_buf,
+            .size=2*PW_EEPROM_SIZE_TEXT_FOUND,
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_TEXT_ITEM_NAMES,
+                .use_alt=false
+            }
+        };
         uint8_t chosen_item_index = pw_item_id_to_item_index(s->dowsing.chosen_item);
 
         pw_eeprom_read(
@@ -497,7 +526,8 @@ void pw_dowsing_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *s
             16*s->dowsing.item_position+4, BUSH_HEIGHT,
             8, 8,
             PW_EEPROM_ADDR_IMG_ITEM,
-            PW_EEPROM_SIZE_IMG_ITEM
+            PW_EEPROM_SIZE_IMG_ITEM,
+            true
         );
 
         if(s->dowsing.choices_remaining > 0) {

--- a/src/apps/app_first_comms.c
+++ b/src/apps/app_first_comms.c
@@ -92,14 +92,30 @@ void pw_first_comms_init_display(pw_state_t *s, const screen_flags_t *sf) {
 
     pw_screen_clear();
 
-    pw_img_t img = {.height=32, .width=32, .size=256, .data=eeprom_buf};
+    pw_img_t img = {
+        .width=32,
+        .height=32,
+        .data=eeprom_buf,
+        .size=256, 
+        .lookup_table = {
+            .addr=PW_FLASH_IMG_POKEWALKER,
+            .use_alt=false
+        }
+    };
     pw_flash_read(PW_FLASH_IMG_POKEWALKER, img.data);
     pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-32)/2, (PW_SCREEN_HEIGHT-32)/2);
 
-    img.width = 16;
-    img.height = 8;
-    img.size = 0x20;
-    pw_flash_read(PW_FLASH_IMG_FACE_NEUTRAL, img.data);
+    pw_img_t face = {
+        .width=16, 
+        .height=8, 
+        .data=eeprom_buf,
+        .size=32,
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
+    };
+    pw_flash_read(PW_FLASH_IMG_FACE_NEUTRAL, face.data);
     pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-16)/2, (PW_SCREEN_HEIGHT-8)/2);
 
 }
@@ -128,7 +144,16 @@ void pw_first_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
     case COMM_STATE_DISCONNECTED: {
         switch(s->comms.screen_state) {
         case FC_SUBSTATE_WAITING: {
-            pw_img_t img = {.width=8, .height=8, .size=16, .data=eeprom_buf};
+            pw_img_t img = {
+                .width=8,
+                .height=8,
+                .data=eeprom_buf,
+                .size=16,
+                .lookup_table = {
+                    .addr=PW_FLASH_IMG_UP_ARROW,
+                    .use_alt=false
+                }
+            };
             if(sf->frame&ANIM_FRAME_NORMAL_TIME) {
                 pw_flash_read(PW_FLASH_IMG_UP_ARROW, img.data);
                 pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-8)/2, 48);
@@ -136,16 +161,33 @@ void pw_first_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 pw_screen_clear_area((PW_SCREEN_WIDTH-8)/2, 48, 8, 8);
             }
 
-            img.width = 16;
-            img.size=32;
-            pw_flash_read(PW_FLASH_IMG_FACE_NEUTRAL, img.data);
+            pw_img_t face = {
+                .width=16, 
+                .height=8, 
+                .data=eeprom_buf,
+                .size=32, 
+                .lookup_table = {
+                    .addr=PW_FLASH_IMG_FACE_NEUTRAL,
+                    .use_alt=false
+                }
+            };
+            pw_flash_read(PW_FLASH_IMG_FACE_NEUTRAL, face.data);
             pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-16)/2, (PW_SCREEN_HEIGHT-8)/2);
 
             break;
         }
         case FC_SUBSTATE_TIMEOUT: {
             pw_screen_clear_area((PW_SCREEN_WIDTH-8)/2, 0, 8, 8);
-            pw_img_t face = {.width=16, .height=8, .size=32, .data=eeprom_buf};
+            pw_img_t face = {
+                .width=16, 
+                .height=8, 
+                .data=eeprom_buf,
+                .size=32, 
+                .lookup_table = {
+                    .addr=PW_FLASH_IMG_FACE_SAD,
+                    .use_alt=false
+                }
+            };
             pw_flash_read(PW_FLASH_IMG_FACE_SAD, face.data);
             pw_screen_draw_img(&face, (PW_SCREEN_WIDTH-16)/2, (PW_SCREEN_HEIGHT-8)/2);
             s->comms.timer--;
@@ -156,13 +198,31 @@ void pw_first_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
     }
     case COMM_STATE_AWAITING:
     case COMM_STATE_SLAVE: {
-        pw_img_t face = {.width=16, .height=8, .size=32, .data=eeprom_buf};
+        pw_img_t face = {
+            .width=16, 
+            .height=8,
+            .data=eeprom_buf,
+            .size=32,
+            .lookup_table = {
+                .addr=PW_FLASH_IMG_FACE_HAPPY,
+                .use_alt=false
+            }
+        };
         pw_flash_read(PW_FLASH_IMG_FACE_HAPPY, face.data);
         pw_screen_draw_img(&face, (PW_SCREEN_WIDTH-16)/2, (PW_SCREEN_HEIGHT-8)/2);
         pw_screen_clear_area((PW_SCREEN_WIDTH-8)/2, 48, 8, 8);
 
         if(sf->frame&ANIM_FRAME_NORMAL_TIME) {
-            pw_img_t img = {.width=8, .height=8, .size=16, .data=eeprom_buf};
+            pw_img_t img = {
+                .width=8,
+                .height=8,
+                .data=eeprom_buf,
+                .size=16,
+                .lookup_table = {
+                    .addr=PW_FLASH_IMG_IR_ACTIVE,
+                    .use_alt=false
+                }
+            };
             pw_flash_read(PW_FLASH_IMG_IR_ACTIVE, img.data);
             pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-8)/2, 0);
         } else {

--- a/src/apps/app_inventory.c
+++ b/src/apps/app_inventory.c
@@ -197,7 +197,8 @@ static void draw_cursor(pw_state_t *s, const screen_flags_t *sf) {
         cx, cy,
         8, 8,
         addr,
-        PW_EEPROM_SIZE_IMG_ARROW
+        PW_EEPROM_SIZE_IMG_ARROW,
+        false
     );
 }
 
@@ -205,16 +206,32 @@ static void draw_cursor(pw_state_t *s, const screen_flags_t *sf) {
 static void draw_animated_sprite(pw_state_t *s, const screen_flags_t *sf) {
 
     uint8_t *buf = eeprom_buf;
-    pw_img_t sprite;
+    pw_img_t sprite = {
+        .width=32,
+        .height=24,
+        .data=buf,
+        .size=192, // 32*24/4
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=true
+        }
+    };
 
     if(s->inventory.current_cursor == PI_EMPTY_SLOT) return;
     bool is_pokemon = s->inventory.current_substate == SUBSCREEN_FOUND && s->inventory.current_cursor < PI_EMPTY_SLOT;
 
 
     if(is_pokemon) {
-        pokemon_index_t pokemon_index = pw_pokemon_id_to_pokemon_index(gdetailed.entries[s->inventory.current_cursor]);
-        pw_pokemon_index_to_small_sprite(pokemon_index, buf, (sf->frame&ANIM_FRAME_NORMAL_TIME)>>ANIM_FRAME_NORMAL_TIME_OFFSET);
+        pw_eeprom_addr_t addr;
+        pokemon_summary_t pokemon;
+        pokemon_index_t pokemon_index = pw_pokemon_id_to_pokemon_index(gdetailed.entries[s->inventory.current_cursor], &pokemon);
+        pw_pokemon_index_to_small_sprite(pokemon_index, buf, (sf->frame&ANIM_FRAME_NORMAL_TIME)>>ANIM_FRAME_NORMAL_TIME_OFFSET, &addr);
+        sprite.lookup_table.addr = addr;
+        sprite.lookup_table.metadata.pokemon.species = pokemon.le_species;
+        sprite.lookup_table.metadata.pokemon.pokemon_flags_1 = pokemon.pokemon_flags_1;
+        sprite.lookup_table.metadata.pokemon.pokemon_flags_2 = pokemon.pokemon_flags_2;
     } else {
+        sprite.lookup_table.addr = PW_EEPROM_ADDR_IMG_TREASURE_LARGE;
         pw_eeprom_read(
             PW_EEPROM_ADDR_IMG_TREASURE_LARGE,
             buf,
@@ -222,9 +239,6 @@ static void draw_animated_sprite(pw_state_t *s, const screen_flags_t *sf) {
         );
     }
 
-    sprite = (pw_img_t) {
-        .data=buf, .width=32, .height=24, .size=32*24/4
-    };
     pw_screen_draw_img(&sprite, PW_SCREEN_WIDTH-32-4, PW_SCREEN_HEIGHT-16-24);
 
 }
@@ -242,17 +256,32 @@ static void draw_name(pw_state_t *s, const screen_flags_t *sf) {
 
     if(is_pokemon) {
         // we're looking at a pokemon
-        pokemon_index_t pokemon_index = pw_pokemon_id_to_pokemon_index(gdetailed.entries[s->inventory.current_cursor]);
+        pokemon_summary_t pokemon;
+        pokemon_index_t pokemon_index = pw_pokemon_id_to_pokemon_index(gdetailed.entries[s->inventory.current_cursor], &pokemon);
         pw_pokemon_index_to_name(pokemon_index, buf);
         sprite = (pw_img_t) {
-            .width=80, .height=16, .data=buf, .size=PW_EEPROM_SIZE_TEXT_POKEMON_NAME
+            .width=80,
+            .height=16,
+            .data=buf,
+            .size=PW_EEPROM_SIZE_TEXT_POKEMON_NAME,
+            .lookup_table = {
+                .addr=-1,
+                .use_alt=false
+            }
         };
     } else {
         // we're looking at an item
         uint8_t item_idx = pw_item_id_to_item_index(gdetailed.entries[s->inventory.current_cursor]);
         pw_item_index_to_name(item_idx, buf);
         sprite = (pw_img_t) {
-            .width=96, .height=16, .data=buf, PW_EEPROM_SIZE_TEXT_ITEM_NAME_SINGLE
+            .width=96,
+            .height=16,
+            .data=buf,
+            .size=PW_EEPROM_SIZE_TEXT_ITEM_NAME_SINGLE,
+            .lookup_table = {
+                .addr=-1,
+                .use_alt=false
+            }
         };
     }
 
@@ -268,31 +297,52 @@ static void pw_inventory_draw_screen1(pw_state_t *s, const screen_flags_t *sf) {
         0, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
+        false
     );
 
     pw_screen_draw_from_eeprom(
         PW_SCREEN_WIDTH-8, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RIGHT,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT,
+        false
     );
 
     pw_screen_draw_from_eeprom(
         8, 0,
         80, 16,
         PW_EEPROM_ADDR_IMG_MENU_TITLE_INVENTORY,
-        PW_EEPROM_SIZE_IMG_MENU_TITLE_INVENTORY
+        PW_EEPROM_SIZE_IMG_MENU_TITLE_INVENTORY,
+        false
     );
 
     // Draw icons
     uint8_t buf_pokeball[PW_EEPROM_SIZE_IMG_BALL];
     uint8_t buf_item[PW_EEPROM_SIZE_IMG_ITEM];
 
-    pw_img_t pokeball = {.height=8, .width=8, .data=buf_pokeball, .size=PW_EEPROM_SIZE_IMG_BALL};
+    pw_img_t pokeball = {
+        .width=8,
+        .height=8,
+        .data=buf_pokeball,
+        .size=PW_EEPROM_SIZE_IMG_BALL,
+        .lookup_table = {
+            .addr=PW_EEPROM_ADDR_IMG_BALL,
+            .use_alt=true
+        }
+    };
     pw_eeprom_read(PW_EEPROM_ADDR_IMG_BALL, buf_pokeball, PW_EEPROM_SIZE_IMG_BALL);
 
-    pw_img_t item = {.height=8, .width=8, .data=buf_item, .size=PW_EEPROM_SIZE_IMG_ITEM};
+    pw_img_t item = {
+        .width=8,
+        .height=8,
+        .data=buf_item,
+        .size=PW_EEPROM_SIZE_IMG_ITEM,
+        .lookup_table = {
+            .addr=PW_EEPROM_ADDR_IMG_ITEM,
+            .use_alt=true
+        }
+    };
     pw_eeprom_read(PW_EEPROM_ADDR_IMG_ITEM, buf_item, PW_EEPROM_SIZE_IMG_ITEM);
 
     uint8_t xs[] = {8, 24, 32, 40, 48};
@@ -319,7 +369,8 @@ static void pw_inventory_draw_screen1(pw_state_t *s, const screen_flags_t *sf) {
             xs[4], yp,
             8, 8,
             PW_EEPROM_ADDR_IMG_BALL_LIGHT,
-            PW_EEPROM_SIZE_IMG_BALL_LIGHT
+            PW_EEPROM_SIZE_IMG_BALL_LIGHT,
+            true
         );
     }
 
@@ -329,7 +380,8 @@ static void pw_inventory_draw_screen1(pw_state_t *s, const screen_flags_t *sf) {
             xs[4], yi,
             8, 8,
             PW_EEPROM_ADDR_IMG_ITEM_LIGHT,
-            PW_EEPROM_SIZE_IMG_ITEM_LIGHT
+            PW_EEPROM_SIZE_IMG_ITEM_LIGHT,
+            true
         );
     }
 
@@ -349,19 +401,30 @@ static void pw_inventory_draw_screen2(pw_state_t *s, const screen_flags_t *sf) {
         0, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_LEFT,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_LEFT
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_LEFT,
+        false
     );
 
     pw_screen_draw_from_eeprom(
         8, 0,
         80, 16,
         PW_EEPROM_ADDR_IMG_MENU_TITLE_INVENTORY,
-        PW_EEPROM_SIZE_IMG_MENU_TITLE_INVENTORY
+        PW_EEPROM_SIZE_IMG_MENU_TITLE_INVENTORY,
+        false
     );
 
 
     uint8_t buf_item[PW_EEPROM_SIZE_IMG_ITEM];
-    pw_img_t item = {.height=8, .width=8, .data=buf_item, .size=PW_EEPROM_SIZE_IMG_ITEM};
+    pw_img_t item = {
+        .width=8,
+        .height=8,
+        .data=buf_item,
+        .size=PW_EEPROM_SIZE_IMG_ITEM,
+        .lookup_table = {
+            .addr=PW_EEPROM_ADDR_IMG_ITEM,
+            .use_alt=true
+        }
+    };
     pw_eeprom_read(PW_EEPROM_ADDR_IMG_ITEM, buf_item, PW_EEPROM_SIZE_IMG_ITEM);
 
     uint8_t x0 = 16, y0 = 24;
@@ -382,7 +445,8 @@ static void pw_inventory_draw_screen2(pw_state_t *s, const screen_flags_t *sf) {
             PW_SCREEN_WIDTH-32-4, PW_SCREEN_HEIGHT-16-24,
             32, 24,
             PW_EEPROM_ADDR_IMG_PRESENT_LARGE,
-            PW_EEPROM_SIZE_IMG_PRESENT_LARGE
+            PW_EEPROM_SIZE_IMG_PRESENT_LARGE,
+            true
         );
 
         draw_name(s, sf);

--- a/src/apps/app_picowalker.c
+++ b/src/apps/app_picowalker.c
@@ -96,7 +96,11 @@ static void draw_color_option(pw_screen_pos_t x, pw_screen_pos_t y) {
             .width = 48,
             .height = 16,
             .data = color_fancy_text,
-            .size = 48*16/4
+            .size = 48*16/4,
+            .lookup_table = {
+                .addr=-1,
+                .use_alt=false
+            }
         };
         pw_screen_draw_img(&img, x, y);
         x = 56;
@@ -190,8 +194,6 @@ void pw_picowalker_settings_update_display(pw_state_t *s, const screen_flags_t *
             8, 8
         );
     }
-    pw_screen_pos_t x, y;
-    pw_img_t img;
 
     draw_color_option(8, 16);
 

--- a/src/apps/app_picowalker.c
+++ b/src/apps/app_picowalker.c
@@ -8,16 +8,19 @@
 #include "../debug_log.h"
 #include "../eeprom_map.h"
 #include "../pico_roms.h"
+#include "../picowalker_core.h"
 #include "../picowalker_structures.h"
 #include "../power.h"
+#include "../globals.h"
+#include "../eeprom.h"
 #include "../screen.h"
+#include "../audio.h"
 #include "../states.h"
 
-#define N_ENTRIES 2
+#define N_ENTRIES 1
 
 // TODO: Move me
 #define N_COLOR_MODES 4
-uint8_t color_mode = 0;
 
 
 enum {
@@ -65,14 +68,18 @@ void pw_picowalker_settings_handle_input(pw_state_t *s, const screen_flags_t *sf
             if(s->picowalker.cursor < 0) {
                 s->picowalker.current_substate = SUBSTATE_GO_TO_SETTINGS;
             }
+            pw_audio_play_sound(SOUND_NAVIGATE_BACK);
             break;
         }
         case PW_BUTTON_M: {
             if(s->picowalker.cursor == 0) {
-                color_mode = (color_mode + 1) % N_COLOR_MODES;
+                pw_color_mode = (pw_color_mode + 1) % N_COLOR_MODES;
+                health_data_cache.color_mode = pw_color_mode;
+                pw_eeprom_write_health_data(&health_data_cache);
             } else {
                 s->picowalker.current_substate = SUBSTATE_GO_TO_SPLASH;
             }
+            pw_audio_play_sound(SOUND_NAVIGATE_MENU);
             break;
         }
         case PW_BUTTON_R: {
@@ -84,6 +91,7 @@ void pw_picowalker_settings_handle_input(pw_state_t *s, const screen_flags_t *sf
         default: {
             pw_log_error("Unknown input %d in substate %s\n",
                     b, state_strings[s->sid]);
+            pw_audio_play_sound(SOUND_CURSOR_MOVE);
             break;
         }
     }
@@ -91,7 +99,7 @@ void pw_picowalker_settings_handle_input(pw_state_t *s, const screen_flags_t *sf
 
 
 static void draw_color_option(pw_screen_pos_t x, pw_screen_pos_t y) {
-    if(color_mode == (N_COLOR_MODES-1)) {
+    if(pw_color_mode == (N_COLOR_MODES-1)) {
         pw_img_t img = (pw_img_t) {
             .width = 48,
             .height = 16,
@@ -104,7 +112,6 @@ static void draw_color_option(pw_screen_pos_t x, pw_screen_pos_t y) {
         };
         pw_screen_draw_img(&img, x, y);
         x = 56;
-        pw_screen_clear_area(x, y, PW_SCREEN_WIDTH-x, 16);
     } else {
         pw_img_t img = (pw_img_t) {
             .width = 48,
@@ -114,8 +121,9 @@ static void draw_color_option(pw_screen_pos_t x, pw_screen_pos_t y) {
         };
         pw_screen_draw_img(&img, x, y);
         x = PW_SCREEN_WIDTH;
-        x = pw_screen_draw_integer(color_mode, x, y);
+        x = pw_screen_draw_integer(pw_color_mode, x, y);
     }
+    pw_screen_clear_area(x, y, PW_SCREEN_WIDTH-x, 16);
 }
 
 void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
@@ -198,7 +206,7 @@ void pw_picowalker_settings_update_display(pw_state_t *s, const screen_flags_t *
     draw_color_option(8, 16);
 
     // Draw battery percentage
-    pw_screen_pos_t y = 16;
+    pw_screen_pos_t y = 32;
     pw_screen_pos_t x = 8;
     pw_img_t img = (pw_img_t) {
         .width=48,

--- a/src/apps/app_picowalker.c
+++ b/src/apps/app_picowalker.c
@@ -121,17 +121,22 @@ void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf
 
     // Title bar
     pw_img_t img = (pw_img_t){
-        .width = 80,
-        .height = 16,
-        .data = picowalker_border_text,
-        .size = 80*16/4
+        .width=80,
+        .height=16,
+        .data=picowalker_border_text,
+        .size=80*16/4,
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
     };
     pw_screen_draw_img(&img, 8, 0);
     pw_screen_draw_from_eeprom(
         0, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
+        false
     );
 
     draw_color_option(8, 16);
@@ -140,10 +145,14 @@ void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf
     y = 32;
     x = 8;
     img = (pw_img_t) {
-        .width = 48,
-        .height = 16,
-        .data = battery_fancy_text,
-        .size = 48*16/4
+        .width=48,
+        .height=16,
+        .data=battery_fancy_text,
+        .size=32*16/4, // 48*16/4
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
     };
     pw_screen_draw_img(&img, x, y);
     uint8_t percent = pw_power_get_battery();
@@ -151,10 +160,14 @@ void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf
     x = pw_screen_draw_integer(percent, x, y);
 
     img = (pw_img_t) {
-        .width = 8,
-        .height = 16,
-        .data = percent_char,
-        .size = 8*16/4
+        .width=8,
+        .height=16,
+        .data=percent_char,
+        .size=8*16/4,
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
     };
     pw_screen_draw_img(&img, PW_SCREEN_WIDTH-8, y);
 }
@@ -167,7 +180,8 @@ void pw_picowalker_settings_update_display(pw_state_t *s, const screen_flags_t *
         0, 16+4+s->picowalker.cursor*16,
         8, 8,
         addr,
-        PW_EEPROM_SIZE_IMG_ARROW
+        PW_EEPROM_SIZE_IMG_ARROW,
+        false
     );
     for(int8_t i = 0; i < N_ENTRIES; i++) {
         if(i == s->picowalker.cursor) continue;
@@ -182,13 +196,17 @@ void pw_picowalker_settings_update_display(pw_state_t *s, const screen_flags_t *
     draw_color_option(8, 16);
 
     // Draw battery percentage
-    y = 32;
-    x = 8;
-    img = (pw_img_t) {
-        .width = 48,
-        .height = 16,
-        .data = battery_fancy_text,
-        .size = 48*16/4
+    pw_screen_pos_t y = 16;
+    pw_screen_pos_t x = 8;
+    pw_img_t img = (pw_img_t) {
+        .width=48,
+        .height=16,
+        .data=battery_fancy_text,
+        .size=32*16/4, // 48*16/4
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
     };
     pw_screen_draw_img(&img, x, y);
     uint8_t percent = pw_power_get_battery();
@@ -196,10 +214,14 @@ void pw_picowalker_settings_update_display(pw_state_t *s, const screen_flags_t *
     x = pw_screen_draw_integer(percent, x, y);
 
     img = (pw_img_t) {
-        .width = 8,
-        .height = 16,
-        .data = percent_char,
-        .size = 8*16/4
+        .width=8,
+        .height=16,
+        .data=percent_char,
+        .size=8*16/4,
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
     };
     pw_screen_draw_img(&img, PW_SCREEN_WIDTH-8, y);
 }

--- a/src/apps/app_poke_radar.c
+++ b/src/apps/app_poke_radar.c
@@ -38,7 +38,8 @@ static void draw_cursor_update(pw_state_t *s, const screen_flags_t *sf) {
         bush_xs[s->radar.user_cursor]-8, bush_ys[s->radar.user_cursor]+8,
         8, 8,
         (sf->frame&ANIM_FRAME_NORMAL_TIME)? PW_EEPROM_ADDR_IMG_ARROW_RIGHT_NORMAL:PW_EEPROM_ADDR_IMG_ARROW_RIGHT_OFFSET,
-        PW_EEPROM_SIZE_IMG_ARROW
+        PW_EEPROM_SIZE_IMG_ARROW,
+        false
     );
 
     for(uint8_t i = 0; i < 4; i++) {
@@ -83,7 +84,16 @@ void pw_poke_radar_init_display(pw_state_t *s, const screen_flags_t *sf) {
     (void)sf;
     switch(s->radar.current_substate) {
     case RADAR_CHOOSING: {
-        pw_img_t bush = {.width=32, .height=24, .data=eeprom_buf, .size=192};
+        pw_img_t bush = {
+            .width=32,
+            .height=24,
+            .data=eeprom_buf,
+            .size=192,
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_IMG_RADAR_BUSH,
+                .use_alt=true
+            }
+        };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_BUSH, eeprom_buf, PW_EEPROM_SIZE_IMG_RADAR_BUSH);
 
         for(uint8_t i = 0; i < 4; i++)
@@ -97,7 +107,8 @@ void pw_poke_radar_init_display(pw_state_t *s, const screen_flags_t *sf) {
             bush_xs[s->radar.active_bush]+16, bush_ys[s->radar.active_bush],
             16, 16,
             PW_EEPROM_ADDR_IMG_RADAR_CLICK,
-            PW_EEPROM_SIZE_IMG_RADAR_CLICK
+            PW_EEPROM_SIZE_IMG_RADAR_CLICK,
+            true
         );
         break;
     }
@@ -139,7 +150,8 @@ void pw_poke_radar_update_display(pw_state_t *s, const screen_flags_t *sf) {
             bush_xs[s->radar.active_bush]+16, bush_ys[s->radar.active_bush],
             16, 16,
             PW_EEPROM_ADDR_IMG_RADAR_BUBBLE_ONE + radar_level_to_index[s->radar.current_level]*PW_EEPROM_SIZE_IMG_RADAR_BUBBLE_ONE,
-            PW_EEPROM_SIZE_IMG_RADAR_BUBBLE_ONE
+            PW_EEPROM_SIZE_IMG_RADAR_BUBBLE_ONE,
+            true
         );
 
         if(s->radar.active_timer > 0) {

--- a/src/apps/app_settings.c
+++ b/src/apps/app_settings.c
@@ -95,32 +95,40 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 0,
             80, 16,
             PW_EEPROM_ADDR_IMG_MENU_TITLE_SETTINGS,
-            PW_EEPROM_SIZE_IMG_MENU_TITLE_SETTINGS
+            PW_EEPROM_SIZE_IMG_MENU_TITLE_SETTINGS,
+            false
         );
         pw_screen_draw_from_eeprom(
             0, 0,
             8, 16,
             PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
-            PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN
+            PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
+            false
         );
         pw_screen_draw_from_eeprom(
             8, 16,
             40, 16,
             PW_EEPROM_ADDR_IMG_SOUND_FRAME,
-            PW_EEPROM_SIZE_IMG_SOUND_FRAME
+            PW_EEPROM_SIZE_IMG_SOUND_FRAME,
+            true
         );
         pw_screen_draw_from_eeprom(
             56, 16,
             40, 16,
             PW_EEPROM_ADDR_IMG_SHADE_FRAME,
-            PW_EEPROM_SIZE_IMG_SHADE_FRAME
+            PW_EEPROM_SIZE_IMG_SHADE_FRAME,
+            true
         );
 
         pw_img_t img = (pw_img_t){
-            .width = 88,
-            .height = 16,
-            .data = picowalker_fancy_text,
-            .size = 88*16/4
+            .width=88,
+            .height=16,
+            .data=picowalker_fancy_text,
+            .size=88*16/4,
+            .lookup_table = {
+                .addr=-1,
+                .use_alt=false
+            }
         };
         pw_screen_draw_img(&img, 8, 40);
         break;
@@ -131,25 +139,29 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             s->settings.main_cursor*48, 16+4,
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_RIGHT_INVERT,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
         pw_screen_draw_from_eeprom(
             8, 40,
             24, 16,
             PW_EEPROM_ADDR_IMG_SPEAKER_OFF,
-            PW_EEPROM_SIZE_IMG_SPEAKER_OFF
+            PW_EEPROM_SIZE_IMG_SPEAKER_OFF,
+            true
         );
         pw_screen_draw_from_eeprom(
             40, 40,
             24, 16,
             PW_EEPROM_ADDR_IMG_SPEAKER_LOW,
-            PW_EEPROM_SIZE_IMG_SPEAKER_LOW
+            PW_EEPROM_SIZE_IMG_SPEAKER_LOW,
+            true
         );
         pw_screen_draw_from_eeprom(
             72, 40,
             24, 16,
             PW_EEPROM_ADDR_IMG_SPEAKER_HIGH,
-            PW_EEPROM_SIZE_IMG_SPEAKER_HIGH
+            PW_EEPROM_SIZE_IMG_SPEAKER_HIGH,
+            true
         );
 
         pw_eeprom_addr_t addr = sf->frame&ANIM_FRAME_NORMAL_TIME?PW_EEPROM_ADDR_IMG_ARROW_RIGHT_NORMAL:
@@ -158,7 +170,8 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             s->settings.sub_cursor*32, 40+4,
             8, 8,
             addr,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
 
         break;
@@ -168,11 +181,18 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             s->settings.main_cursor*48, 16+4,
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_RIGHT_INVERT,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
         pw_img_t shade_bars = {
-            .width=8, .height=16,
-            .data=eeprom_buf, .size=PW_EEPROM_ADDR_IMG_CONTRAST_DEMONSTRATOR
+            .width=8,
+            .height=16,
+            .data=eeprom_buf,
+            .size=PW_EEPROM_ADDR_IMG_CONTRAST_DEMONSTRATOR,
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_IMG_CONTRAST_DEMONSTRATOR,
+                .use_alt=true
+            }
         };
         pw_eeprom_read(
             PW_EEPROM_ADDR_IMG_CONTRAST_DEMONSTRATOR,
@@ -190,7 +210,8 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             8+s->settings.sub_cursor*8, 32,
             8, 8,
             addr,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
 
         pw_screen_pos_t x = 8+N_SHADE_OPTIONS*8;
@@ -218,7 +239,8 @@ void pw_settings_update_display(pw_state_t *s, const screen_flags_t *sf) {
             cursor_positions[c][0], cursor_positions[c][1],
             8, 8,
             addr,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
         for(int i = 0; i < N_MAIN_OPTIONS; i++) {
             if(i == s->settings.main_cursor) continue;
@@ -238,7 +260,8 @@ void pw_settings_update_display(pw_state_t *s, const screen_flags_t *sf) {
             s->settings.sub_cursor*32, 40+4,
             8, 8,
             addr,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
         for(int i = 0; i < N_SOUND_OPTIONS; i++) {
             if(i == s->settings.sub_cursor) continue;
@@ -256,7 +279,8 @@ void pw_settings_update_display(pw_state_t *s, const screen_flags_t *sf) {
                 8+s->settings.sub_cursor*8, 32,
                 8, 8,
                 addr,
-                PW_EEPROM_SIZE_IMG_ARROW
+                PW_EEPROM_SIZE_IMG_ARROW,
+                false
             );
             for(int i = 0; i < N_SHADE_OPTIONS; i++) {
                 if(i == s->settings.sub_cursor) continue;

--- a/src/apps/app_splash.c
+++ b/src/apps/app_splash.c
@@ -58,7 +58,8 @@ void pw_splash_init_display(pw_state_t *s, const screen_flags_t *sf) {
             PW_SCREEN_WIDTH-64, 0,
             64, 48,
             PW_EEPROM_ADDR_IMG_POKEMON_LARGE_ANIMATED_FRAME2,
-            PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME
+            PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME,
+            true
         );
     }
 
@@ -66,7 +67,8 @@ void pw_splash_init_display(pw_state_t *s, const screen_flags_t *sf) {
         0, PW_SCREEN_HEIGHT-24-16,
         32, 24,
         PW_EEPROM_ADDR_IMG_ROUTE_LARGE,
-        PW_EEPROM_SIZE_IMG_ROUTE_LARGE
+        PW_EEPROM_SIZE_IMG_ROUTE_LARGE,
+        true
     );
 
     for(uint8_t i = 0; i < 3; i++) {
@@ -75,7 +77,8 @@ void pw_splash_init_display(pw_state_t *s, const screen_flags_t *sf) {
                 i*8, PW_SCREEN_HEIGHT-8,
                 8, 8,
                 PW_EEPROM_ADDR_IMG_BALL,
-                PW_EEPROM_SIZE_IMG_BALL
+                PW_EEPROM_SIZE_IMG_BALL,
+                true
             );
         }
     }
@@ -86,7 +89,8 @@ void pw_splash_init_display(pw_state_t *s, const screen_flags_t *sf) {
                 24+i*8, PW_SCREEN_HEIGHT-8,
                 8, 8,
                 PW_EEPROM_ADDR_IMG_ITEM,
-                PW_EEPROM_SIZE_IMG_ITEM
+                PW_EEPROM_SIZE_IMG_ITEM,
+                true
             );
         }
     }
@@ -98,7 +102,8 @@ void pw_splash_init_display(pw_state_t *s, const screen_flags_t *sf) {
                 16+i*8, PW_SCREEN_HEIGHT-16,
                 8, 8,
                 PW_EEPROM_ADDR_IMG_CARD_SUITS+i*PW_EEPROM_SIZE_IMG_CARD_SUIT_SYMBOL,
-                PW_EEPROM_SIZE_IMG_CARD_SUIT_SYMBOL
+                PW_EEPROM_SIZE_IMG_CARD_SUIT_SYMBOL,
+                true
             );
         }
 
@@ -109,7 +114,8 @@ void pw_splash_init_display(pw_state_t *s, const screen_flags_t *sf) {
             0, PW_SCREEN_HEIGHT-16,
             8, 8,
             PW_EEPROM_ADDR_IMG_BALL_LIGHT,
-            PW_EEPROM_SIZE_IMG_BALL_LIGHT
+            PW_EEPROM_SIZE_IMG_BALL_LIGHT,
+            true
         );
     }
 
@@ -118,7 +124,8 @@ void pw_splash_init_display(pw_state_t *s, const screen_flags_t *sf) {
             8, PW_SCREEN_HEIGHT-16,
             8, 8,
             PW_EEPROM_ADDR_IMG_ITEM_LIGHT,
-            PW_EEPROM_SIZE_IMG_ITEM_LIGHT
+            PW_EEPROM_SIZE_IMG_ITEM_LIGHT,
+            true
         );
     }
 
@@ -140,7 +147,8 @@ void pw_splash_update_display(pw_state_t *s, const screen_flags_t *sf) {
             PW_SCREEN_WIDTH-64, 0,
             64, 48,
             frame_addr,
-            PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME
+            PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME,
+            true
         );
 
     }

--- a/src/apps/app_switch.c
+++ b/src/apps/app_switch.c
@@ -35,9 +35,10 @@ void pw_switch_init(pw_state_t *s, const screen_flags_t *sf) {
         break;
     }
     case SWITCH_TYPE_POKEMON: {
+        pokemon_summary_t pokemon;
         for(size_t i = 0; i < 3; i++) {
             s->switches.inv_ids[i] = di.caught_pokemon[i];
-            s->switches.inv_indices[i] = pw_pokemon_id_to_pokemon_index(di.caught_pokemon[i])-1;
+            s->switches.inv_indices[i] = pw_pokemon_id_to_pokemon_index(di.caught_pokemon[i], &pokemon)-1;
         }
         s->switches.switch_index = s->switches.switch_id; // already an index
         break;
@@ -72,14 +73,16 @@ void pw_switch_init_display(pw_state_t *s, const screen_flags_t *sf) {
         0, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
+        false
     );
 
     pw_screen_draw_from_eeprom(
         8, 0,
         80, 16,
         PW_EEPROM_ADDR_TEXT_SWITCH,
-        PW_EEPROM_SIZE_TEXT_SWITCH
+        PW_EEPROM_SIZE_TEXT_SWITCH,
+        false
     );
 
     for(uint8_t i = 0; i < 3; i++) {
@@ -87,7 +90,8 @@ void pw_switch_init_display(pw_state_t *s, const screen_flags_t *sf) {
             20+i*(16+8), PW_SCREEN_HEIGHT-32-8,
             8, 8,
             addr,
-            size
+            size,
+            true
         );
     }
 
@@ -95,7 +99,8 @@ void pw_switch_init_display(pw_state_t *s, const screen_flags_t *sf) {
         20+s->switches.cursor*(16+8), PW_SCREEN_HEIGHT-32,
         8, 8,
         PW_EEPROM_ADDR_IMG_ARROW_UP_NORMAL,
-        PW_EEPROM_SIZE_IMG_ARROW
+        PW_EEPROM_SIZE_IMG_ARROW,
+        false
     );
 }
 
@@ -129,14 +134,16 @@ void pw_switch_update_display(pw_state_t *s, const screen_flags_t *sf) {
             20+s->switches.cursor*(8+16), PW_SCREEN_HEIGHT-32,
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_UP_NORMAL,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
     } else {
         pw_screen_draw_from_eeprom(
             20+s->switches.cursor*(8+16), PW_SCREEN_HEIGHT-32,
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_UP_OFFSET,
-            PW_EEPROM_SIZE_IMG_ARROW
+            PW_EEPROM_SIZE_IMG_ARROW,
+            false
         );
     }
 
@@ -145,7 +152,8 @@ void pw_switch_update_display(pw_state_t *s, const screen_flags_t *sf) {
             0, PW_SCREEN_HEIGHT-16,
             width, 16,
             addr,
-            size
+            size,
+            false
         );
         pw_screen_draw_text_box(0, PW_SCREEN_HEIGHT-16, PW_SCREEN_WIDTH, 16, PW_SCREEN_BLACK);
         s->switches.prev_cursor = s->switches.cursor;

--- a/src/apps/app_trainer_card.c
+++ b/src/apps/app_trainer_card.c
@@ -44,50 +44,58 @@ void pw_trainer_card_init_display(pw_state_t *s, const screen_flags_t *sf) {
         8, 0,
         80, 16,
         PW_EEPROM_ADDR_IMG_MENU_TITLE_TRAINER_CARD,
-        PW_EEPROM_SIZE_IMG_MENU_TITLE_TRAINER_CARD
+        PW_EEPROM_SIZE_IMG_MENU_TITLE_TRAINER_CARD,
+        false
     );
     pw_screen_draw_from_eeprom(
         0, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
+        false
     );
     pw_screen_draw_from_eeprom(
         PW_SCREEN_WIDTH-8, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RIGHT,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT,
+        false
     );
 
     pw_screen_draw_from_eeprom(
         0, 16,
         16, 16,
         PW_EEPROM_ADDR_IMG_PERSON,
-        PW_EEPROM_SIZE_IMG_PERSON
+        PW_EEPROM_SIZE_IMG_PERSON,
+        true
     );
     pw_screen_draw_from_eeprom(
         16, 16,
         80, 16,
         PW_EEPROM_ADDR_IMG_TRAINER_NAME,
-        PW_EEPROM_SIZE_IMG_TRAINER_NAME
+        PW_EEPROM_SIZE_IMG_TRAINER_NAME,
+        false
     );
     pw_screen_draw_from_eeprom(
         0, 32,
         16, 16,
         PW_EEPROM_ADDR_IMG_ROUTE_SMALL,
-        PW_EEPROM_SIZE_IMG_ROUTE_SMALL
+        PW_EEPROM_SIZE_IMG_ROUTE_SMALL,
+        true
     );
     pw_screen_draw_from_eeprom(
         16, 32,
         80, 16,
         PW_EEPROM_ADDR_TEXT_ROUTE_NAME,
-        PW_EEPROM_SIZE_TEXT_ROUTE_NAME
+        PW_EEPROM_SIZE_TEXT_ROUTE_NAME,
+        false
     );
     pw_screen_draw_from_eeprom(
         0, 48,
         32, 16,
         PW_EEPROM_ADDR_IMG_TIME_FRAME,
-        PW_EEPROM_SIZE_IMG_TIME_FRAME
+        PW_EEPROM_SIZE_IMG_TIME_FRAME,
+        false
     );
 
     pw_dhms_t dhms = pw_time_get_dhms();
@@ -102,7 +110,8 @@ void pw_trainer_card_draw_dayview(uint8_t day, uint32_t day_steps,
         x, y,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_LEFT,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_LEFT
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_LEFT,
+        false
     );
     x+=8;
 
@@ -113,7 +122,8 @@ void pw_trainer_card_draw_dayview(uint8_t day, uint32_t day_steps,
         x, y,
         8, 16,
         PW_EEPROM_ADDR_IMG_CHAR_DASH,
-        PW_EEPROM_SIZE_IMG_CHAR
+        PW_EEPROM_SIZE_IMG_CHAR,
+        false
     );
     x+=8;
 
@@ -124,7 +134,8 @@ void pw_trainer_card_draw_dayview(uint8_t day, uint32_t day_steps,
         x, y,
         40, 16,
         PW_EEPROM_ADDR_IMG_DAYS_FRAME,
-        PW_EEPROM_SIZE_IMG_DAYS_FRAME
+        PW_EEPROM_SIZE_IMG_DAYS_FRAME,
+        false
     );
     x+=40;
 
@@ -135,7 +146,8 @@ void pw_trainer_card_draw_dayview(uint8_t day, uint32_t day_steps,
         PW_SCREEN_WIDTH-8, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RIGHT,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT,
+        false
     );
     x+=8;
 
@@ -143,7 +155,8 @@ void pw_trainer_card_draw_dayview(uint8_t day, uint32_t day_steps,
         PW_SCREEN_WIDTH-40, 16,
         40, 16,
         PW_EEPROM_ADDR_IMG_STEPS_FRAME,
-        PW_EEPROM_SIZE_IMG_STEPS_FRAME
+        PW_EEPROM_SIZE_IMG_STEPS_FRAME,
+        false
     );
     pw_screen_pos_t until = pw_screen_draw_integer(day_steps, PW_SCREEN_WIDTH-40, 16);
     pw_screen_clear_area(0, 16, until, 16);
@@ -152,7 +165,8 @@ void pw_trainer_card_draw_dayview(uint8_t day, uint32_t day_steps,
         0, 32,
         64, 16,
         PW_EEPROM_ADDR_IMG_TOTAL_DAYS_FRAME,
-        PW_EEPROM_SIZE_IMG_TOTAL_DAYS_FRAME
+        PW_EEPROM_SIZE_IMG_TOTAL_DAYS_FRAME,
+        false
     );
     until = pw_screen_draw_integer(total_days, PW_SCREEN_WIDTH, 32); // shift x by -1?
     pw_screen_clear_area(64, 32, until-64, 16);
@@ -161,7 +175,8 @@ void pw_trainer_card_draw_dayview(uint8_t day, uint32_t day_steps,
         PW_SCREEN_WIDTH-40, 48,
         40, 16,
         PW_EEPROM_ADDR_IMG_STEPS_FRAME,
-        PW_EEPROM_SIZE_IMG_STEPS_FRAME
+        PW_EEPROM_SIZE_IMG_STEPS_FRAME,
+        false
     );
     until = pw_screen_draw_integer(total_steps, PW_SCREEN_WIDTH-40, 48);
     pw_screen_clear_area(0, 48, until, 16);

--- a/src/ir/ir.c
+++ b/src/ir/ir.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "../debug_log.h"
 #include "ir.h"
 #include "../picowalker_structures.h"
 
@@ -71,9 +72,25 @@ ir_err_t pw_ir_recv_packet(pw_packet_t *packet, size_t len, size_t *pn_read) {
 
     if(packet_chk != chk) return IR_ERR_BAD_CHECKSUM;
 
-    for(size_t i = 0; i < 4; i++) {
-        if(packet->session_id_bytes[i] != g_session_id[i]) return IR_ERR_BAD_SESSID;
+    // Skip session ID check for commands that establish/modify the session
+    // CMD_ASSERT_MASTER (0xFA) - Master is asserting control, brings its own session ID
+    // CMD_ADVERTISING (0xFC) - Advertising doesn't use session IDs
+    uint8_t cmd = packet->cmd;
+    bool skip_session_check = (cmd == 0xFA || cmd == 0xFC);
+
+    pw_log_debug("Session - Expected: %02X%02X%02X%02X, Got: %02X%02X%02X%02X\n",
+                g_session_id[0], g_session_id[1], g_session_id[2], g_session_id[3],
+                packet->session_id_bytes[0], packet->session_id_bytes[1], 
+                packet->session_id_bytes[2], packet->session_id_bytes[3]);
+    if (!skip_session_check) {
+        for(size_t i = 0; i < 4; i++) {
+            if(packet->session_id_bytes[i] != g_session_id[i]) return IR_ERR_BAD_SESSID;
+        }
     }
+
+    // for(size_t i = 0; i < 4; i++) {
+    //     if(packet->session_id_bytes[i] != g_session_id[i]) return IR_ERR_BAD_SESSID;
+    // }
 
     return IR_OK;
 }

--- a/src/menu.c
+++ b/src/menu.c
@@ -171,13 +171,15 @@ static void menu_draw_bottom_numbers(pw_state_t *s, const screen_flags_t *sf) {
             24, PW_SCREEN_HEIGHT-16,
             16, 16,
             PW_EEPROM_ADDR_IMG_WATTS,
-            PW_EEPROM_SIZE_IMG_WATTS
+            PW_EEPROM_SIZE_IMG_WATTS,
+            false
         );
         pw_screen_draw_from_eeprom(
             40, PW_SCREEN_HEIGHT-16,
             8, 16,
             PW_EEPROM_ADDR_IMG_CHAR_SLASH,
-            PW_EEPROM_SIZE_IMG_CHAR
+            PW_EEPROM_SIZE_IMG_CHAR,
+            false
         );
     } else {
         pw_screen_clear_area(0, PW_SCREEN_HEIGHT-16, PW_SCREEN_WIDTH/2, 16);
@@ -187,7 +189,8 @@ static void menu_draw_bottom_numbers(pw_state_t *s, const screen_flags_t *sf) {
         PW_SCREEN_WIDTH-16, PW_SCREEN_HEIGHT-16,
         16, 16,
         PW_EEPROM_ADDR_IMG_WATTS,
-        PW_EEPROM_SIZE_IMG_WATTS
+        PW_EEPROM_SIZE_IMG_WATTS,
+        false
     );
     size_t x = pw_screen_draw_integer(health_data_cache.current_watts, PW_SCREEN_WIDTH-16, PW_SCREEN_HEIGHT-16);
     pw_screen_clear_area(PW_SCREEN_WIDTH/2, PW_SCREEN_HEIGHT-16, x - PW_SCREEN_WIDTH/2, 16);
@@ -204,7 +207,8 @@ static void menu_clear_draw_cursor(pw_state_t *s, const screen_flags_t *sf) {
                 4+i*16, CURSOR_Y_VALUES[i]-8,
                 8, 8,
                 addr,
-                PW_EEPROM_SIZE_IMG_ARROW
+                PW_EEPROM_SIZE_IMG_ARROW,
+                false
             );
         } else {
             pw_screen_clear_area(4+i*16, CURSOR_Y_VALUES[i]-8, 8, 8);
@@ -219,19 +223,22 @@ void pw_menu_init_display(pw_state_t *s, const screen_flags_t *sf) {
         8, 0,
         80, 16,
         MENU_TITLES[s->menu.cursor],
-        PW_EEPROM_SIZE_IMG_MENU_TITLE_CONNECT
+        PW_EEPROM_SIZE_IMG_MENU_TITLE_CONNECT,
+        false
     );
     pw_screen_draw_from_eeprom(
         0, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_LEFT,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_LEFT
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_LEFT,
+        false
     );
     pw_screen_draw_from_eeprom(
         PW_SCREEN_WIDTH-8, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RIGHT,
-        PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT
+        PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT,
+        false
     );
 
     for(int i = 0; i < MENU_SIZE; i++) {
@@ -239,7 +246,8 @@ void pw_menu_init_display(pw_state_t *s, const screen_flags_t *sf) {
             i*16, CURSOR_Y_VALUES[i],
             16, 16,
             MENU_ICONS[i],
-            PW_EEPROM_SIZE_IMG_MENU_ICON_CONNECT
+            PW_EEPROM_SIZE_IMG_MENU_ICON_CONNECT,
+            true
         );
     }
 
@@ -264,7 +272,8 @@ void pw_menu_update_display(pw_state_t *s, const screen_flags_t *sf) {
                 8, 0,
                 80, 16,
                 MENU_TITLES[s->menu.cursor],
-                PW_EEPROM_SIZE_IMG_MENU_TITLE_CONNECT
+                PW_EEPROM_SIZE_IMG_MENU_TITLE_CONNECT,
+                false
             );
 
             break;
@@ -281,7 +290,16 @@ void pw_menu_update_display(pw_state_t *s, const screen_flags_t *sf) {
             //pw_screen_draw_text_box(0, PW_SCREEN_HEIGHT-16, PW_SCREEN_WIDTH, 16, PW_SCREEN_BLACK);
 
             uint16_t addr = PW_EEPROM_ADDR_TEXT_NEED_WATTS + PW_EEPROM_SIZE_TEXT_NEED_WATTS*(s->menu.message-1);
-            pw_img_t img = (pw_img_t){.width=PW_SCREEN_WIDTH, .height=16, .data=eeprom_buf, .size=PW_EEPROM_SIZE_TEXT_NEED_WATTS};
+            pw_img_t img = (pw_img_t) {
+                .width=PW_SCREEN_WIDTH,
+                .height=16,
+                .data=eeprom_buf,
+                .size=PW_EEPROM_SIZE_TEXT_NEED_WATTS,
+                .lookup_table = {
+                    .addr=addr,
+                    .use_alt=false
+                }
+            };
             pw_eeprom_read(addr, eeprom_buf, PW_EEPROM_SIZE_TEXT_NEED_WATTS);
             pw_screen_overlay_text_box(&img, PW_SCREEN_WIDTH, 16, PW_SCREEN_BLACK);
             pw_screen_draw_img(&img, 0, PW_SCREEN_HEIGHT-16);

--- a/src/picowalker.c
+++ b/src/picowalker.c
@@ -96,7 +96,7 @@ void pw_normal_loop() {
     uint64_t td;
 
     // Skip accel/battery checks if we can't afford to hang around
-    /*
+
     if(!is_in_time_sensitive_state(current_state->sid)) {
         walker_timings.now = pw_time_get_us();
         td = (walker_timings.prev_accel_check>walker_timings.now)?(walker_timings.prev_accel_check-walker_timings.now):(walker_timings.now-walker_timings.prev_accel_check);
@@ -104,10 +104,10 @@ void pw_normal_loop() {
             walker_timings.prev_accel_check = walker_timings.now;
             pw_accel_process_steps();
 
-            (void)pw_power_process_battery();
+            // (void)pw_power_process_battery();
         }
     }
-    */
+    
 
     // Update power management
     pw_power_update();

--- a/src/picowalker.c
+++ b/src/picowalker.c
@@ -11,6 +11,7 @@
 #include "eeprom_map.h"
 #include "globals.h"
 #include "ir/ir.h"
+#include "picowalker_core.h"
 #include "picowalker_structures.h"
 #include "power.h"
 #include "rand.h"
@@ -28,6 +29,7 @@ struct {
 pw_state_t a1, a2;
 pw_state_t *current_state = &a1, *pending_state = &a2;
 screen_flags_t screen_flags;
+uint8_t pw_color_mode = 0;
 
 void (*pw_current_loop)(void);
 
@@ -64,7 +66,8 @@ void pw_setup() {
 
     pw_audio_volume = (health_data_cache.settings&SETTINGS_SOUND_MASK)>>SETTINGS_SOUND_OFFSET;
     pw_screen_set_brightness((health_data_cache.settings&SETTINGS_SHADE_MASK)>>SETTINGS_SHADE_OFFSET);
-
+    pw_color_mode = health_data_cache.color_mode;
+    
     if(walker_info_cache.flags & WALKER_INFO_FLAG_INIT) {
         current_state->sid = STATE_SPLASH;
         pending_state->sid = STATE_SPLASH;

--- a/src/picowalker.c
+++ b/src/picowalker.c
@@ -150,7 +150,8 @@ void pw_normal_loop() {
                     0, 0,
                     8, 8,
                     PW_EEPROM_ADDR_IMG_LOW_BATTERY,
-                    PW_EEPROM_SIZE_IMG_LOW_BATTERY
+                    PW_EEPROM_SIZE_IMG_LOW_BATTERY,
+                    true
                 );
             } else {
                 pw_screen_clear_area(0, 0, 8, 8);

--- a/src/picowalker_core.h
+++ b/src/picowalker_core.h
@@ -44,6 +44,10 @@ extern pw_volume_t pw_audio_get_volume();
  */
 extern int pw_power_get_mode();
 
+/**
+ * Current value of color mode
+ */
+extern uint8_t pw_color_mode;
 
 /**
  * Debug log functions

--- a/src/picowalker_structures.h
+++ b/src/picowalker_structures.h
@@ -13,11 +13,32 @@
  *
  */
 
+ /*
+ *  ==================================================================================
+ *  EEPROM
+ *  ==================================================================================
+ */
+
+typedef uint16_t pw_eeprom_addr_t;
+
 /*
  *  ==================================================================================
  *  SCREEN
  *  ==================================================================================
  */
+
+ /**
+ * Pokemon Metadata
+ * uint8_t variant = pokemon_flags_1 & 0x1F;
+ * bool is_female = pokemon_flags_1 & 0x20;
+ * bool has_form = pokemon_flags_2 & 0x01;
+ * bool is_shiny = pokemon_flags_2 & 0x02;
+ */
+ typedef struct {
+    uint16_t species;
+    uint8_t pokemon_flags_1;
+    uint8_t pokemon_flags_2;
+} pw_metadata_t;
 
 #define PW_SCREEN_WIDTH    96
 #define PW_SCREEN_HEIGHT   64
@@ -34,12 +55,20 @@ typedef uint8_t pw_screen_dim_t;
 
 /**
  * An image data structure for pokewalker images
- * Will change when colour images are implemented
  */
 typedef struct pw_img_s {
+    pw_screen_dim_t width, height;
     uint8_t *data;
     size_t size;
-    pw_screen_dim_t height, width;
+
+    struct {
+        pw_eeprom_addr_t addr;
+        bool use_alt: 1;
+    
+        union {
+            pw_metadata_t pokemon;
+        } metadata;
+    } lookup_table;
 } pw_img_t;
 
 
@@ -61,15 +90,6 @@ typedef enum pw_screen_color_e {
  * Value ranges from 0 to 9
  */
 #define PW_SCREEN_MAX_BRIGHTNESS 9
-
-
-/*
- *  ==================================================================================
- *  EEPROM
- *  ==================================================================================
- */
-
-typedef uint16_t pw_eeprom_addr_t;
 
 
 /*

--- a/src/screen.c
+++ b/src/screen.c
@@ -12,14 +12,32 @@
  *  Most of the heavy lifting is done by the driver code
  */
 
-void pw_screen_draw_from_eeprom(pw_screen_pos_t x, pw_screen_pos_t y, pw_screen_dim_t w, pw_screen_dim_t h, pw_eeprom_addr_t addr, size_t len) {
-    pw_img_t img = {.height=h, .width=w, .data=eeprom_buf, .size=len};
+void pw_screen_draw_from_eeprom(pw_screen_pos_t x, pw_screen_pos_t y, pw_screen_dim_t w, pw_screen_dim_t h, pw_eeprom_addr_t addr, size_t len, bool use_alt) {
+    pw_img_t img = {
+        .width=w,
+        .height=h,
+        .data=eeprom_buf,
+        .size=len,
+        .lookup_table = {
+            .addr=addr,
+            .use_alt=use_alt
+        }
+    };
     pw_eeprom_read(addr, eeprom_buf, len);
     pw_screen_draw_img(&img, x, y);
 }
 
 void pw_screen_draw_from_eeprom_with_text_box(pw_screen_pos_t x, pw_screen_pos_t y, pw_screen_dim_t w, pw_screen_dim_t h, pw_eeprom_addr_t addr, size_t len, pw_screen_color_t c) {
-    pw_img_t img = {.height=h, .width=w, .data=eeprom_buf, .size=len};
+    pw_img_t img = {
+        .width=w,
+        .height=h,
+        .data=eeprom_buf,
+        .size=len,
+        .lookup_table = {
+            .addr=addr,
+            .use_alt=false
+        }
+    };
     pw_eeprom_read(addr, eeprom_buf, len);
     pw_screen_overlay_text_box(&img, w, h, c);
     pw_screen_draw_img(&img, x, y);
@@ -38,7 +56,8 @@ pw_screen_pos_t pw_screen_draw_integer(uint32_t n, pw_screen_pos_t right_x, pw_s
             x, y,
             8, 16,
             PW_EEPROM_ADDR_IMG_DIGITS+PW_EEPROM_SIZE_IMG_CHAR*idx,
-            PW_EEPROM_SIZE_IMG_CHAR
+            PW_EEPROM_SIZE_IMG_CHAR,
+            false
         );
     } while(m>0);
 
@@ -55,7 +74,16 @@ pw_screen_pos_t pw_screen_draw_integer_with_overline(uint32_t n, pw_screen_pos_t
         m = m/10;
         x -= 8;
 
-        pw_img_t img = {.width=8, .height=16, .data=eeprom_buf, .size=PW_EEPROM_SIZE_IMG_CHAR};
+        pw_img_t img = {
+            .width=8,
+            .height=16,
+            .data=eeprom_buf,
+            .size=PW_EEPROM_SIZE_IMG_CHAR,
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_IMG_DIGITS+PW_EEPROM_SIZE_IMG_CHAR*idx,
+                .use_alt=false
+            }
+        };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_DIGITS+PW_EEPROM_SIZE_IMG_CHAR*idx, eeprom_buf, PW_EEPROM_SIZE_IMG_CHAR);
         pw_screen_overlay_overline(&img, 8, c);
         pw_screen_draw_img(&img, x, y);
@@ -80,7 +108,8 @@ void pw_screen_draw_subtime(uint8_t n, pw_screen_pos_t x, pw_screen_pos_t y, boo
         x, y,
         8, 16,
         PW_EEPROM_ADDR_IMG_DIGITS+PW_EEPROM_SIZE_IMG_CHAR*idx,
-        PW_EEPROM_SIZE_IMG_CHAR
+        PW_EEPROM_SIZE_IMG_CHAR,
+        false
     );
 
     x += 8;
@@ -89,7 +118,8 @@ void pw_screen_draw_subtime(uint8_t n, pw_screen_pos_t x, pw_screen_pos_t y, boo
         x, y,
         8, 16,
         PW_EEPROM_ADDR_IMG_DIGITS+PW_EEPROM_SIZE_IMG_CHAR*idx,
-        PW_EEPROM_SIZE_IMG_CHAR
+        PW_EEPROM_SIZE_IMG_CHAR,
+        false
     );
     if(draw_colon) {
         x += 8;
@@ -97,7 +127,8 @@ void pw_screen_draw_subtime(uint8_t n, pw_screen_pos_t x, pw_screen_pos_t y, boo
             x, y,
             8, 16,
             PW_EEPROM_ADDR_IMG_CHAR_COLON,
-            PW_EEPROM_SIZE_IMG_CHAR
+            PW_EEPROM_SIZE_IMG_CHAR,
+            false
         );
     }
 }
@@ -114,9 +145,14 @@ void pw_screen_draw_message(pw_screen_pos_t y, uint8_t message_index, pw_screen_
     pw_eeprom_read(addr, eeprom_buf, sz);
 
     pw_img_t img = {
-        .width=PW_SCREEN_WIDTH, .height=h,
+        .width=PW_SCREEN_WIDTH, 
+        .height=h,
         .data=eeprom_buf,
-        .size=sz
+        .size=sz,
+        .lookup_table = {
+            .addr=addr,
+            .use_alt=false
+        }
     };
 
     pw_screen_draw_img(&img, 0, y);
@@ -134,17 +170,32 @@ void pw_screen_draw_message_with_text_box(pw_screen_pos_t y, uint8_t message_ind
     pw_eeprom_read(addr, eeprom_buf, sz);
 
     pw_img_t img = {
-        .width=PW_SCREEN_WIDTH, .height=h,
+        .width=PW_SCREEN_WIDTH, 
+        .height=h,
         .data=eeprom_buf,
-        .size=sz
+        .size=sz,
+        .lookup_table = {
+            .addr=addr,
+            .use_alt=false
+        }
     };
+
     pw_screen_overlay_text_box(&img, PW_SCREEN_WIDTH, h, c);
 
     pw_screen_draw_img(&img, 0, y);
 }
 
 void pw_screen_draw_pokemon_name_and_message(pw_eeprom_addr_t poke_addr, pw_eeprom_addr_t message_addr, pw_screen_color_t c) {
-    pw_img_t img = {.width=PW_SCREEN_WIDTH, .height=32, .data=eeprom_buf, .size=2*PW_EEPROM_SIZE_TEXT_APPEARED};
+    pw_img_t img = {
+        .width=PW_SCREEN_WIDTH,
+        .height=32,
+        .data=eeprom_buf,
+        .size=2*PW_EEPROM_SIZE_TEXT_APPEARED,
+        .lookup_table = {
+            .addr=poke_addr,
+            .use_alt=false
+        }
+    };
     pw_eeprom_read(
         poke_addr,
         img.data,

--- a/src/screen.h
+++ b/src/screen.h
@@ -19,7 +19,8 @@ void pw_screen_draw_from_eeprom(
     pw_screen_pos_t x, pw_screen_pos_t y,
     pw_screen_dim_t w, pw_screen_dim_t h,
     pw_eeprom_addr_t addr,
-    size_t len
+    size_t len,
+    bool use_alt
 );
 pw_screen_pos_t pw_screen_draw_integer(uint32_t n, pw_screen_pos_t right_x, pw_screen_pos_t y);
 void pw_screen_draw_time(uint8_t hour, uint8_t minute, uint8_t second, pw_screen_pos_t x, pw_screen_pos_t y);

--- a/src/types.h
+++ b/src/types.h
@@ -102,7 +102,8 @@ typedef struct {
     /* +0x10 */ uint16_t walk_minute_counter;   // BE in walker
     /* +0x12 */ uint8_t  steps_this_watt;
     /* +0x13 */ uint8_t  event_log_index;
-    /* +0x14 */ uint8_t  padding[3];
+    /* +0x14 */ uint8_t  padding[2];
+    /* +0x16 */ uint8_t  color_mode;
     /* +0x17 */ uint8_t  settings;              // [0]=special_map, [1..2]=volume, [3..6]=contrast
 } health_data_t;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -133,17 +133,17 @@ void pw_read_inventory(pw_brief_inventory_t *brief, pw_detailed_inventory_t *det
 
 }
 
-void pw_pokemon_index_to_small_sprite(pokemon_index_t idx, uint8_t *buf, uint8_t frame) {
-    pw_eeprom_addr_t addr;
+void pw_pokemon_index_to_small_sprite(pokemon_index_t idx, uint8_t *buf, uint8_t frame, pw_eeprom_addr_t *addr) {
+    // pw_eeprom_addr_t addr;
 
     switch(idx) {
     case PIDX_WALKING: {
-        addr = PW_EEPROM_ADDR_IMG_POKEMON_SMALL_ANIMATED +
+        *addr = PW_EEPROM_ADDR_IMG_POKEMON_SMALL_ANIMATED +
                frame*PW_EEPROM_SIZE_IMG_POKEMON_SMALL_ANIMATED_FRAME;
         break;
     }
     case PIDX_EXTRA: {
-        addr = PW_EEPROM_ADDR_IMG_EVENT_POKEMON_SMALL_ANIMATED +
+        *addr = PW_EEPROM_ADDR_IMG_EVENT_POKEMON_SMALL_ANIMATED +
                frame*PW_EEPROM_SIZE_IMG_EVENT_POKEMON_SMALL_ANIMATED_FRAME;
         break;
     }
@@ -151,7 +151,7 @@ void pw_pokemon_index_to_small_sprite(pokemon_index_t idx, uint8_t *buf, uint8_t
     case PIDX_OPTION_B:
     case PIDX_OPTION_C: {
         uint8_t offs = 2*(idx-1);
-        addr = PW_EEPROM_ADDR_IMG_ROUTE_POKEMON_SMALL_ANIMATED
+        *addr = PW_EEPROM_ADDR_IMG_ROUTE_POKEMON_SMALL_ANIMATED
                + (offs+frame)*PW_EEPROM_SIZE_IMG_POKEMON_SMALL_ANIMATED_FRAME;
         break;
     }
@@ -161,7 +161,7 @@ void pw_pokemon_index_to_small_sprite(pokemon_index_t idx, uint8_t *buf, uint8_t
     }
     }
 
-    pw_eeprom_read(addr, buf, PW_EEPROM_SIZE_IMG_POKEMON_SMALL_ANIMATED_FRAME);
+    pw_eeprom_read(*addr, buf, PW_EEPROM_SIZE_IMG_POKEMON_SMALL_ANIMATED_FRAME);
 
 }
 
@@ -221,7 +221,7 @@ void pw_item_index_to_name(uint8_t idx, uint8_t *buf) {
  *
  *  @return `pokemon_index_t` containing which route pokemon slot it is
  */
-pokemon_index_t pw_pokemon_id_to_pokemon_index(uint16_t id) {
+pokemon_index_t pw_pokemon_id_to_pokemon_index(uint16_t id, pokemon_summary_t *pokemon) {
     pokemon_summary_t pokes[N_PIDX];
 
     pw_eeprom_read(
@@ -243,7 +243,10 @@ pokemon_index_t pw_pokemon_id_to_pokemon_index(uint16_t id) {
     );
 
     for(size_t i = 0; i < N_PIDX; i++) {
-        if(pokes[i].le_species == id) return (pokemon_index_t)i;
+        if(pokes[i].le_species == id) {
+            *pokemon = pokes[i];
+            return (pokemon_index_t)i;
+        }
     }
 
     // unreachable, hopefully

--- a/src/utils.h
+++ b/src/utils.h
@@ -86,10 +86,10 @@ inline uint32_t swap_bytes_u32(uint32_t x) {
 
 void pw_read_inventory(pw_brief_inventory_t *brief, pw_detailed_inventory_t *detailed);
 
-void pw_pokemon_index_to_small_sprite(pokemon_index_t idx, uint8_t *buf, uint8_t frame);
+void pw_pokemon_index_to_small_sprite(pokemon_index_t idx, uint8_t *buf, uint8_t frame, pw_eeprom_addr_t *addr);
 void pw_pokemon_index_to_name(pokemon_index_t idx, uint8_t *buf);
 void pw_item_index_to_name(uint8_t idx, uint8_t *buf);
-pokemon_index_t pw_pokemon_id_to_pokemon_index(uint16_t id);
+pokemon_index_t pw_pokemon_id_to_pokemon_index(uint16_t id, pokemon_summary_t *pokemon);
 uint8_t pw_item_id_to_item_index(uint16_t id);
 
 //int nintendo_to_ascii(uint8_t *str, char* buf, size_t len);


### PR DESCRIPTION
There are some minor bugs that need to be fixed down in the upstream that are not color related so I will leave those in good hands. :)

- **feature colour images** - Major feature: Added color image support across entire codebase (18 files modified). Updated screen rendering, lookup tables, and all app displays to support color modes
- **enabled accel check on normal loop** - Re-enabled accelerometer checking because it wasn't generating watts
 - **bad session id work around** - Added workaround for IR communication session ID issues
- **clean up rebase colour feature** - Code cleanup after rebasing the color feature branch
- **pw_color_mode settings** - Implemented persistent storage for color mode setting using `health_data.padding[3]` as `health_data.color_mode`. Color mode now saves/loads across power cycles

We should now be able to close `feature: colour images` #9 