### PR TITLE
App Battle full color and More Message animation prompt

### DIFF
--- a/src/apps/app_battle.c
+++ b/src/apps/app_battle.c
@@ -136,7 +136,7 @@ void pw_battle_init(pw_state_t *s, const screen_flags_t *sf) {
     s->battle.wobbles = 0;
     s->battle.update_hp = 0;
 
-    pw_audio_play_sound(SOUND_POKEMON_ENCOUNTER);
+    pw_audio_play_sound(SOUND_BATTLE_ENCOUNTER);
 }
 
 /**
@@ -204,12 +204,10 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
                 case ACTION_EVADE: {
                     substate_queue[0] = BATTLE_STAREDOWN;
                     substate_queue[1] = BATTLE_CHOOSING;
-		    pw_audio_play_sound(SOUND_NAVIGATE_MENU);
                     break;
                 }
                 case ACTION_SPECIAL: {
                     substate_queue[0] = BATTLE_THEY_FLED;
-		    pw_audio_play_sound(SOUND_MINIGAME_FAIL);
                     break;
                 }
                 }
@@ -257,14 +255,25 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
             uint8_t our_hp   = (s->battle.current_hp&OUR_HP_MASK)>>OUR_HP_OFFSET;
             uint8_t their_hp = (s->battle.current_hp&THEIR_HP_MASK)>>THEIR_HP_OFFSET;
 
-            if(our_action != ACTION_EVADE) {
-                switch(their_action) {
-                    case ACTION_ATTACK: our_hp -= 1; break;
-                    case ACTION_SPECIAL: our_hp -= 1; break;
-                    case ACTION_EVADE: our_hp -= 1; break;
-                }
+            switch(our_action) {
+                case ACTION_ATTACK:
+                    if (their_action == ACTION_EVADE) {
+                        our_hp -= 1;
+                        pw_audio_play_sound(SOUND_BATTLE_HIT);
+                    } else {
+                        our_hp -= 1;
+                        pw_audio_play_sound(SOUND_BATTLE_HIT);
+                    }
+                    break;
+                case ACTION_EVADE:
+                    if (their_action == ACTION_ATTACK || their_action == ACTION_SPECIAL) {
+                        pw_audio_play_sound(SOUND_BATTLE_EVADE);
+                    }
+                    break;
+                case ACTION_SPECIAL:
+                    our_hp -= 1;
+                    break;
             }
-
             s->battle.update_hp &= ~0x01;
             s->battle.current_hp = our_hp<<OUR_HP_OFFSET | their_hp<<THEIR_HP_OFFSET;
         }
@@ -292,15 +301,31 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
             uint8_t our_hp   = (s->battle.current_hp&OUR_HP_MASK)>>OUR_HP_OFFSET;
             uint8_t their_hp = (s->battle.current_hp&THEIR_HP_MASK)>>THEIR_HP_OFFSET;
 
-            if(our_action == ACTION_EVADE) {
-                if(their_action == ACTION_ATTACK) their_hp -= 1;
-            } else {
-                switch(their_action) {
-                    case ACTION_ATTACK: their_hp -= 1; break;
-                    case ACTION_SPECIAL: their_hp -= 2; break;
-                }
+            switch(their_action) {
+                case ACTION_ATTACK:
+                    if (our_action == ACTION_EVADE) {
+                        their_hp -= 1;
+                        pw_audio_play_sound(SOUND_BATTLE_HIT);
+                    } else {
+                        their_hp -= 1;
+                        pw_audio_play_sound(SOUND_BATTLE_HIT);
+                    }
+                    break;
+                case ACTION_EVADE:
+                    if (our_action == ACTION_ATTACK) {
+                        pw_audio_play_sound(SOUND_BATTLE_EVADE);
+                    }
+                    break;
+                case ACTION_SPECIAL:
+                    if (our_action == ACTION_EVADE) {
+                        their_hp -= 1;
+                        pw_audio_play_sound(SOUND_BATTLE_HIT);
+                    } else {
+                        their_hp -= 2;
+                        pw_audio_play_sound(SOUND_BATTLE_CRITICAL);
+                    }
+                    break;
             }
-
             s->battle.update_hp &= ~0x02;
             s->battle.current_hp = our_hp<<OUR_HP_OFFSET | their_hp<<THEIR_HP_OFFSET;
         }
@@ -328,6 +353,9 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
         break;
     }
     case BATTLE_THEY_FLED: {
+        if(s->battle.anim_frame == 3) {
+            pw_audio_play_sound(SOUND_BATTLE_FLED);
+        }
         if(s->battle.anim_frame >= MESSAGE_DISPLAY_ANIM_LENGTH) {
             event_log_item_t *event_log = (event_log_item_t*)(decompression_buf);
             route_info_t *route_info = (route_info_t*)(decompression_buf + sizeof(event_log_item_t));
@@ -351,12 +379,11 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
         break;
     }
     case BATTLE_CATCH_SETUP: {
-
+        pw_audio_play_sound(SOUND_BATTLE_POKEBALL_THROW);
         substate_queue[0] = BATTLE_THREW_BALL;
         substate_queue[1] = BATTLE_CLOUD_ANIM;
 
         int8_t health = (s->battle.current_hp&THEIR_HP_MASK) >> THEIR_HP_OFFSET;
-        uint8_t catch_chance = CATCH_CHANCES[health-1];
         if(health <= 0) {
             substate_queue[0] = BATTLE_THEY_FLED;
             s->battle.substate_queue_len = 1;
@@ -366,6 +393,7 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
         // 1-3 wobbles, can flee at three wobbles
         bool caught = true;
         uint8_t n_wobbles = 0;
+        uint8_t catch_chance = CATCH_CHANCES[health-1];
         while((n_wobbles < 3) && caught) {
             n_wobbles++;
             uint8_t pct = pw_rand()%100;
@@ -447,6 +475,9 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
         break;
     }
     case BATTLE_POKEMON_CAUGHT: {
+        if(s->battle.anim_frame <= MESSAGE_DISPLAY_ANIM_LENGTH) {
+            pw_audio_play_sound(SOUND_BATTLE_CAUGHT);
+        }
         if(s->battle.anim_frame >= MESSAGE_DISPLAY_ANIM_LENGTH) { }
         break;
     }
@@ -562,13 +593,14 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
         event_log_item_t *event_log = (event_log_item_t*)(decompression_buf);
         route_info_t *route_info = (route_info_t*)(decompression_buf + sizeof(event_log_item_t));
         pw_eeprom_read(PW_EEPROM_ADDR_ROUTE_INFO, (uint8_t*)route_info, sizeof(route_info_t));
-
-
         // TODO: Read special route flag
         pw_log_event(event_log, route_info, event_log_type, 0, false, s->battle.chosen_pokemon+1);
         break;
     }
     case BATTLE_CATCH_STARS: {
+        if (s->battle.anim_frame == 3) {
+            pw_audio_play_sound(SOUND_NAVIGATE_MENU);
+        }
         if(s->battle.anim_frame >= CATCH_ANIM_LENGTH) {
             s->battle.substate_queue_index++;
             s->battle.anim_frame = 0;
@@ -1043,6 +1075,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
     }
     case BATTLE_THEY_FLED: {
         // TODO: animation
+        s->battle.anim_frame++;
         break;
     }
     case BATTLE_STAREDOWN: {
@@ -1160,6 +1193,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         break;
     }
     case BATTLE_POKEMON_CAUGHT: {
+        s->battle.anim_frame++;
         break;
     }
     default: {
@@ -1198,7 +1232,6 @@ void pw_battle_handle_input(pw_state_t *s, const screen_flags_t *sf, pw_buttons_
         }
         case PW_BUTTON_M: {
             pw_battle_switch_substate(s, BATTLE_CATCH_SETUP);
-	    pw_audio_play_sound(SOUND_POKEBALL_THROW);
             break;
         }
         }

--- a/src/apps/app_battle.c
+++ b/src/apps/app_battle.c
@@ -590,7 +590,12 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
 
 void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
 
+    route_info_t route_info;
+    pw_eeprom_read(PW_EEPROM_ADDR_ROUTE_INFO, (uint8_t*)(&route_info), sizeof(route_info_t));
+
     pw_eeprom_addr_t our_addr;
+    pokemon_summary_t our_pokemon;
+
     pw_img_t our_sprite = {
         .width=32,
         .height=24,
@@ -598,13 +603,19 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
         .size=192,
         .lookup_table = {
             .addr=-1,
-            .use_alt=false
+            .use_alt=true
         }
     };
-    pw_pokemon_index_to_small_sprite(PIDX_WALKING, our_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &our_addr);
+    pokemon_index_t our_index = pw_pokemon_id_to_pokemon_index(route_info.pokemon_summary.le_species, &our_pokemon);
+    pw_pokemon_index_to_small_sprite(our_index, our_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &our_addr);
     our_sprite.lookup_table.addr = our_addr;
+    our_sprite.lookup_table.metadata.pokemon.species = our_pokemon.le_species;
+    our_sprite.lookup_table.metadata.pokemon.pokemon_flags_1 = our_pokemon.pokemon_flags_1;
+    our_sprite.lookup_table.metadata.pokemon.pokemon_flags_2 = our_pokemon.pokemon_flags_2;
 
     pw_eeprom_addr_t their_addr;
+    pokemon_summary_t their_pokemon;
+
     pw_img_t their_sprite = {
         .width=32,
         .height=24,
@@ -612,11 +623,15 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
         .size=192,
         .lookup_table = {
             .addr=-1,
-            .use_alt=false
+            .use_alt=true
         }
     };
-    pw_pokemon_index_to_small_sprite(s->battle.chosen_pokemon+1, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &their_addr);
+    pokemon_index_t their_index = pw_pokemon_id_to_pokemon_index(route_info.route_pokemon[s->battle.chosen_pokemon+1].le_species, &their_pokemon);
+    pw_pokemon_index_to_small_sprite(their_index, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &their_addr);
     their_sprite.lookup_table.addr = their_addr;
+    their_sprite.lookup_table.metadata.pokemon.species = their_pokemon.le_species;
+    their_sprite.lookup_table.metadata.pokemon.pokemon_flags_1 = their_pokemon.pokemon_flags_1;
+    their_sprite.lookup_table.metadata.pokemon.pokemon_flags_2 = their_pokemon.pokemon_flags_2;
 
     switch(s->battle.current_substate) {
     case BATTLE_OPENING: {
@@ -842,6 +857,30 @@ void battle_draw_hp_bars(pw_img_t *battle_buffer, pw_state_t *s) {
 
 }
 
+void draw_hp_bars(pw_state_t *s) {
+
+    pw_img_t hp_sprite = {
+        .width=8,
+        .height=8,
+        .data=decompression_buf,
+        .size=PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP,
+        .lookup_table = {
+            .addr=PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP,
+            .use_alt=true
+        }
+    };
+    pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP, hp_sprite.data, PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP);
+
+    uint8_t their_hp = (s->battle.current_hp&THEIR_HP_MASK)>>THEIR_HP_OFFSET;
+    for(uint8_t i = 0; i < their_hp; i++) {
+        pw_screen_draw_img(&hp_sprite, 8*(i+1), 24);
+    }
+
+    uint8_t our_hp = (s->battle.current_hp&OUR_HP_MASK)>>OUR_HP_OFFSET;
+    for(uint8_t i = 0; i < our_hp; i++) {
+        pw_screen_draw_img(&hp_sprite, PW_SCREEN_WIDTH/2+8*(i+1), 0);
+    }
+}
 /*
  * coords:
  *   - i attack, they attack: me attack + they hit ("i attacked")-> me hit + they attack ("they attacked")
@@ -861,6 +900,11 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         return;
     }
 
+    route_info_t route_info;
+    pw_eeprom_read(PW_EEPROM_ADDR_ROUTE_INFO, (uint8_t*)(&route_info), sizeof(route_info_t));
+
+    pw_eeprom_addr_t our_addr;
+    pokemon_summary_t our_pokemon;
     pw_img_t our_sprite   = {
         .width=32,
         .height=24,
@@ -868,10 +912,18 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         .size=192,
         .lookup_table = {
             .addr=-1,
-            .use_alt=false
+            .use_alt=true
         }
     };
-    //pw_img_t their_sprite = {.width=32, .height=24, .size=192, .data=decompression_buf};
+    pokemon_index_t our_index = pw_pokemon_id_to_pokemon_index(route_info.pokemon_summary.le_species, &our_pokemon);
+    pw_pokemon_index_to_small_sprite(our_index, our_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &our_addr);
+    our_sprite.lookup_table.addr = our_addr;
+    our_sprite.lookup_table.metadata.pokemon.species = our_pokemon.le_species;
+    our_sprite.lookup_table.metadata.pokemon.pokemon_flags_1 = our_pokemon.pokemon_flags_1;
+    our_sprite.lookup_table.metadata.pokemon.pokemon_flags_2 = our_pokemon.pokemon_flags_2;
+
+    pw_eeprom_addr_t their_addr;
+    pokemon_summary_t their_pokemon;
     pw_img_t their_sprite = {
         .width=32,
         .height=24,
@@ -879,22 +931,20 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         .size=192,
         .lookup_table = {
             .addr=-1,
-            .use_alt=false
+            .use_alt=true
         }
     };
-    pw_img_t battle_buffer;
-    pw_screen_get_blank_image(&battle_buffer, 96, 32);
-    if(battle_buffer.size == 0) {
-        pw_log_error("Couldn't get blank image for battles\n");
-        return;
-    }
-
-    pw_eeprom_addr_t our_addr;
-    pw_pokemon_index_to_small_sprite(PIDX_WALKING, our_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &our_addr);
+    pokemon_index_t their_index = pw_pokemon_id_to_pokemon_index(route_info.route_pokemon[s->battle.chosen_pokemon+1].le_species, &their_pokemon);
+    pw_pokemon_index_to_small_sprite(their_index, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &their_addr);
+    their_sprite.lookup_table.addr = their_addr;
+    their_sprite.lookup_table.metadata.pokemon.species = their_pokemon.le_species;
+    their_sprite.lookup_table.metadata.pokemon.pokemon_flags_1 = their_pokemon.pokemon_flags_1;
+    their_sprite.lookup_table.metadata.pokemon.pokemon_flags_2 = their_pokemon.pokemon_flags_2;
     
-    pw_eeprom_addr_t their_addr;
-    pw_pokemon_index_to_small_sprite(s->battle.chosen_pokemon+1, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &their_addr);
-
+    uint8_t count = 0;
+    pw_img_queue_t queue[5];
+    pw_screen_clear_area(0, 0, 96, 32);
+    
     switch(s->battle.current_substate) {
     case BATTLE_OPENING: {
         if(s->battle.anim_frame > 0) s->battle.anim_frame--;
@@ -902,28 +952,26 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         break;
     }
     case BATTLE_APPEARED: {
-        pw_screen_overlay_img(&battle_buffer, &their_sprite, 8, 0);
-        pw_screen_overlay_img(&battle_buffer, &our_sprite, PW_SCREEN_WIDTH/2+8, 8);
-        battle_draw_hp_bars(&battle_buffer, s);
-
-        pw_screen_draw_img(&battle_buffer, 0, 0);
+        queue[count++] = (pw_img_queue_t){&our_sprite, PW_SCREEN_WIDTH/2+8, 8};
+        queue[count++] = (pw_img_queue_t){&their_sprite, 8, 0};
+        pw_screen_draw_queue(queue, count);
+        draw_hp_bars(s);
         break;
     }
     case BATTLE_CHOOSING: {
-        pw_screen_overlay_img(&battle_buffer, &their_sprite, 8, 0);
-        pw_screen_overlay_img(&battle_buffer, &our_sprite, PW_SCREEN_WIDTH/2+8, 8);
-        battle_draw_hp_bars(&battle_buffer, s);
-
-        pw_screen_draw_img(&battle_buffer, 0, 0);
+        queue[count++] = (pw_img_queue_t){&our_sprite, PW_SCREEN_WIDTH/2+8, 8};
+        queue[count++] = (pw_img_queue_t){&their_sprite, 8, 0};
+        pw_screen_draw_queue(queue, count);
+        draw_hp_bars(s);
         break;
     }
     case BATTLE_OUR_ACTION: {
         //uint8_t our_action = (s->battle.actions&OUR_ACTION_MASK)>>OUR_ACTION_OFFSET;
         uint8_t their_action = (s->battle.actions&THEIR_ACTION_MASK)>>THEIR_ACTION_OFFSET;
 
-        pw_screen_overlay_img(&battle_buffer, &our_sprite, OUR_ATTACK_XS[0][s->battle.anim_frame], 8);
-        pw_screen_overlay_img(&battle_buffer, &their_sprite, OUR_ATTACK_XS[1][s->battle.anim_frame], 0);
-        battle_draw_hp_bars(&battle_buffer, s);
+        queue[count++] = (pw_img_queue_t){&our_sprite, OUR_ATTACK_XS[0][s->battle.anim_frame], 8};
+        queue[count++] = (pw_img_queue_t){&their_sprite, OUR_ATTACK_XS[1][s->battle.anim_frame], 0};
+        draw_hp_bars(s);
 
         if(s->battle.anim_frame == (ATTACK_ANIM_LENGTH+1)/2) {
             if(their_action == ACTION_SPECIAL) {
@@ -938,7 +986,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
                     }
                 };
                 pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_CRITICAL_HIT, crit_hit.data, PW_EEPROM_SIZE_IMG_RADAR_CRITICAL_HIT);
-                pw_screen_overlay_img(&battle_buffer, &crit_hit, (PW_SCREEN_WIDTH-16)/2, 0);
+                queue[count++] = (pw_img_queue_t){&crit_hit, (PW_SCREEN_WIDTH-16)/2, 0};
 
             } else if(their_action != ACTION_EVADE) {
                 pw_img_t normal_hit = {
@@ -952,12 +1000,12 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
                     }
                 };
                 pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_ATTACK_HIT, normal_hit.data, PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT);
-                pw_screen_overlay_img(&battle_buffer, &normal_hit, (PW_SCREEN_WIDTH-16)/2, 0);
+                queue[count++] = (pw_img_queue_t){&normal_hit, (PW_SCREEN_WIDTH-16)/2, 0};
             }
 
         }
 
-        pw_screen_draw_img(&battle_buffer, 0, 0);
+        pw_screen_draw_queue(queue, count);
         s->battle.anim_frame++;
         break;
     }
@@ -965,9 +1013,9 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         uint8_t our_action = (s->battle.actions&OUR_ACTION_MASK)>>OUR_ACTION_OFFSET;
         //uint8_t their_action = (s->battle.actions&THEIR_ACTION_MASK)>>THEIR_ACTION_OFFSET;
 
-        pw_screen_overlay_img(&battle_buffer, &our_sprite, THEIR_ATTACK_XS[0][s->battle.anim_frame], 8);
-        pw_screen_overlay_img(&battle_buffer, &their_sprite, THEIR_ATTACK_XS[1][s->battle.anim_frame], 0);
-        battle_draw_hp_bars(&battle_buffer, s);
+        queue[count++] = (pw_img_queue_t){&our_sprite, THEIR_ATTACK_XS[0][s->battle.anim_frame], 8};
+        queue[count++] = (pw_img_queue_t){&their_sprite, THEIR_ATTACK_XS[1][s->battle.anim_frame], 0};
+        draw_hp_bars(s);
 
         if(s->battle.anim_frame == (ATTACK_ANIM_LENGTH+1)/2) {
             if(our_action != ACTION_EVADE) {
@@ -982,11 +1030,11 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
                     }
                 };
                 pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_ATTACK_HIT, normal_hit.data, PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT);
-                pw_screen_overlay_img(&battle_buffer, &normal_hit, (PW_SCREEN_WIDTH-16)/2, 0);
+                queue[count++] = (pw_img_queue_t){&normal_hit, (PW_SCREEN_WIDTH-16)/2, 0};
             }
         }
 
-        pw_screen_draw_img(&battle_buffer, 0, 0);
+        pw_screen_draw_queue(queue, count);
         s->battle.anim_frame++;
         break;
     }
@@ -998,17 +1046,17 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         break;
     }
     case BATTLE_STAREDOWN: {
-        pw_screen_overlay_img(&battle_buffer, &our_sprite, THEIR_ATTACK_XS[0][0], 8);
-        pw_screen_overlay_img(&battle_buffer, &their_sprite, THEIR_ATTACK_XS[1][0], 0);
-        battle_draw_hp_bars(&battle_buffer, s);
-        pw_screen_draw_img(&battle_buffer, 0, 0);
+        queue[count++] = (pw_img_queue_t){&our_sprite, THEIR_ATTACK_XS[0][0], 8};
+        queue[count++] = (pw_img_queue_t){&their_sprite, THEIR_ATTACK_XS[1][0], 0};
+        draw_hp_bars(s);
+        pw_screen_draw_queue(queue, count);
         s->battle.anim_frame++;
         break;
     }
     case BATTLE_THREW_BALL: {
-        pw_screen_overlay_img(&battle_buffer, &our_sprite, THEIR_ATTACK_XS[0][0], 8);
-        pw_screen_overlay_img(&battle_buffer, &their_sprite, THEIR_ATTACK_XS[1][0], 0);
-
+        queue[count++] = (pw_img_queue_t){&our_sprite, THEIR_ATTACK_XS[0][0], 8};
+        queue[count++] = (pw_img_queue_t){&their_sprite, THEIR_ATTACK_XS[1][0], 0};
+        
         pw_img_t ball = {
             .width=8, 
             .height=8,
@@ -1020,9 +1068,9 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             }
         };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_BALL, ball.data, PW_EEPROM_SIZE_IMG_BALL);
-        pw_screen_overlay_img(&battle_buffer, &ball, POKEBALL_THROW_XS[s->battle.anim_frame], POKEBALL_THROW_YS[s->battle.anim_frame]);
 
-        pw_screen_draw_img(&battle_buffer, 0, 0);
+        queue[count++] = (pw_img_queue_t){&ball, POKEBALL_THROW_XS[s->battle.anim_frame], POKEBALL_THROW_YS[s->battle.anim_frame]};
+        pw_screen_draw_queue(queue, count);
         s->battle.anim_frame++;
         break;
     }
@@ -1053,7 +1101,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         }
         }
 
-        pw_screen_overlay_img(&battle_buffer, &our_sprite, THEIR_ATTACK_XS[0][0], 8);
+        queue[count++] = (pw_img_queue_t){&our_sprite, THEIR_ATTACK_XS[0][0], 8};
 
         pw_img_t ball = {
             .width=8,
@@ -1066,22 +1114,21 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             }
         };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_BALL, ball.data, PW_EEPROM_SIZE_IMG_BALL);
-        pw_screen_overlay_img(&battle_buffer, &ball, x, 16);
 
-        pw_screen_draw_img(&battle_buffer, 0, 0);
+        queue[count++] = (pw_img_queue_t){&ball, x, 16};
+        pw_screen_draw_queue(queue, count);
         s->battle.anim_frame++;
         break;
     }
     case BATTLE_ALMOST_HAD_IT: {
-        pw_screen_overlay_img(&battle_buffer, &our_sprite, THEIR_ATTACK_XS[0][0], 8);
-        pw_screen_overlay_img(&battle_buffer, &their_sprite, THEIR_ATTACK_XS[1][0], 8);
-
-        pw_screen_draw_img(&battle_buffer, 0, 0);
+        queue[count++] = (pw_img_queue_t){&our_sprite, THEIR_ATTACK_XS[0][0], 8};
+        queue[count++] = (pw_img_queue_t){&their_sprite, THEIR_ATTACK_XS[1][0], 8};
+        pw_screen_draw_queue(queue, count);
         s->battle.anim_frame++;
         break;
     }
     case BATTLE_CATCH_STARS: {
-        pw_screen_overlay_img(&battle_buffer, &our_sprite, THEIR_ATTACK_XS[0][0], 8);
+        queue[count++] = (pw_img_queue_t){&our_sprite, THEIR_ATTACK_XS[0][0], 8};
 
         pw_img_t star = {
             .width=8,
@@ -1094,7 +1141,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             }
         };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_CATCH_EFFECT, star.data, PW_EEPROM_SIZE_IMG_RADAR_CATCH_EFFECT);
-        pw_screen_overlay_img(&battle_buffer, &star, THEIR_NORMAL_X, THEIR_NORMAL_Y+8-s->battle.anim_frame);
+        queue[count++] = (pw_img_queue_t){&star, THEIR_NORMAL_X, THEIR_NORMAL_Y+8-s->battle.anim_frame};
 
         pw_img_t ball = {
             .width=8,
@@ -1107,9 +1154,8 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             }
         };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_BALL, ball.data, PW_EEPROM_SIZE_IMG_BALL);
-        pw_screen_overlay_img(&battle_buffer, &ball, THEIR_NORMAL_X+8, 16);
-
-        pw_screen_draw_img(&battle_buffer, 0, 0);
+        queue[count++] = (pw_img_queue_t){&ball, THEIR_NORMAL_X+8, 16};
+        pw_screen_draw_queue(queue, count);
         s->battle.anim_frame++;
         break;
     }

--- a/src/apps/app_battle.c
+++ b/src/apps/app_battle.c
@@ -1174,6 +1174,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_CATCH_EFFECT, star.data, PW_EEPROM_SIZE_IMG_RADAR_CATCH_EFFECT);
         queue[count++] = (pw_img_queue_t){&star, THEIR_NORMAL_X, THEIR_NORMAL_Y+8-s->battle.anim_frame};
+        queue[count++] = (pw_img_queue_t){&star, THEIR_NORMAL_X+16, THEIR_NORMAL_Y+8-s->battle.anim_frame};
 
         pw_img_t ball = {
             .width=8,
@@ -1192,6 +1193,22 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         break;
     }
     case BATTLE_POKEMON_CAUGHT: {
+        queue[count++] = (pw_img_queue_t){&our_sprite, THEIR_ATTACK_XS[0][0], 8};
+
+        pw_img_t ball = {
+            .width=8,
+            .height=8,
+            .data=decompression_buf,
+            .size=16,
+            .lookup_table = {
+                .addr=PW_EEPROM_ADDR_IMG_BALL,
+                .use_alt=true
+            }
+        };
+        pw_eeprom_read(PW_EEPROM_ADDR_IMG_BALL, ball.data, PW_EEPROM_SIZE_IMG_BALL);
+        queue[count++] = (pw_img_queue_t){&ball, THEIR_NORMAL_X+8, 16};
+        pw_screen_draw_queue(queue, count);
+
         s->battle.anim_frame++;
         break;
     }

--- a/src/apps/app_battle.c
+++ b/src/apps/app_battle.c
@@ -90,7 +90,7 @@ const pw_screen_pos_t THEIR_ATTACK_XS[2][ATTACK_ANIM_LENGTH] = {
 
 const pw_screen_pos_t POKEBALL_THROW_XS[6] = { 44, 40, 36, 32, 28, 24 };
 const pw_screen_pos_t POKEBALL_THROW_YS[6] = { 20, 14,  9,  6,  4,  6 };
-const int8_t POKEMON_ENTER_XS[4] = { -16, -4, 8, 8 };
+const pw_screen_pos_t POKEMON_ENTER_XS[6] = { -16, -8, -4,  0,  4,  8 };
 
 
 #define WOBBLE_INITIAL_X 16
@@ -153,10 +153,17 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
     case BATTLE_OPENING: {
         if(s->battle.anim_frame <= 0) {
             pw_battle_switch_substate(s, BATTLE_APPEARED);
+            s->battle.anim_frame = 0;
         }
         break;
     }
     case BATTLE_APPEARED: {
+        if(s->battle.anim_frame >= 5) {
+            pw_battle_switch_substate(s, BATTLE_CHOOSING);
+            s->battle.anim_frame = 0;
+        } else {
+            s->battle.anim_frame++;
+        }
         break;
     }
     case BATTLE_CHOOSING: {
@@ -658,7 +665,7 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
             .use_alt=true
         }
     };
-    pokemon_index_t their_index = pw_pokemon_id_to_pokemon_index(route_info.route_pokemon[s->battle.chosen_pokemon+1].le_species, &their_pokemon);
+    pokemon_index_t their_index = pw_pokemon_id_to_pokemon_index(route_info.route_pokemon[s->battle.chosen_pokemon].le_species, &their_pokemon);
     pw_pokemon_index_to_small_sprite(their_index, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &their_addr);
     their_sprite.lookup_table.addr = their_addr;
     their_sprite.lookup_table.metadata.pokemon.species = their_pokemon.le_species;
@@ -671,7 +678,7 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
         break;
     }
     case BATTLE_APPEARED: {
-        pw_screen_draw_img(&their_sprite, THEIR_NORMAL_X, THEIR_NORMAL_Y);
+        // pw_screen_draw_img(&their_sprite, THEIR_NORMAL_X, THEIR_NORMAL_Y);
         pw_screen_draw_img(&our_sprite, OUR_NORMAL_X, OUR_NORMAL_Y);
 
         pw_screen_draw_pokemon_name_and_message(
@@ -928,8 +935,10 @@ void draw_hp_bars(pw_state_t *s) {
 void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
     if(s->battle.current_substate != s->battle.previous_substate) {
         s->battle.previous_substate = s->battle.current_substate;
-        pw_battle_init_display(s, sf);
-        return;
+        if(s->battle.current_substate != BATTLE_APPEARED) {
+            pw_battle_init_display(s, sf);
+            return;
+        }
     }
 
     route_info_t route_info;
@@ -966,7 +975,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             .use_alt=true
         }
     };
-    pokemon_index_t their_index = pw_pokemon_id_to_pokemon_index(route_info.route_pokemon[s->battle.chosen_pokemon+1].le_species, &their_pokemon);
+    pokemon_index_t their_index = pw_pokemon_id_to_pokemon_index(route_info.route_pokemon[s->battle.chosen_pokemon].le_species, &their_pokemon);
     pw_pokemon_index_to_small_sprite(their_index, their_sprite.data, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &their_addr);
     their_sprite.lookup_table.addr = their_addr;
     their_sprite.lookup_table.metadata.pokemon.species = their_pokemon.le_species;
@@ -984,7 +993,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
     }
     case BATTLE_APPEARED: {
         queue[count++] = (pw_img_queue_t){&our_sprite, PW_SCREEN_WIDTH/2+8, 8};
-        queue[count++] = (pw_img_queue_t){&their_sprite, 8, 0};
+        queue[count++] = (pw_img_queue_t){&their_sprite, POKEMON_ENTER_XS[s->battle.anim_frame], 0};//8, 0};
         pw_screen_draw_queue(queue, count);
         draw_hp_bars(s);
         break;

--- a/src/apps/app_battle.c
+++ b/src/apps/app_battle.c
@@ -90,7 +90,7 @@ const pw_screen_pos_t THEIR_ATTACK_XS[2][ATTACK_ANIM_LENGTH] = {
 
 const pw_screen_pos_t POKEBALL_THROW_XS[6] = { 44, 40, 36, 32, 28, 24 };
 const pw_screen_pos_t POKEBALL_THROW_YS[6] = { 20, 14,  9,  6,  4,  6 };
-const pw_screen_pos_t POKEMON_ENTER_XS[6] = { -16, -8, -4,  0,  4,  8 };
+const pw_screen_pos_t POKEMON_ENTER_XS[4] = { -16, -4, 8, 8 };
 
 
 #define WOBBLE_INITIAL_X 16
@@ -135,6 +135,7 @@ void pw_battle_init(pw_state_t *s, const screen_flags_t *sf) {
     s->battle.current_hp = (4<<OUR_HP_OFFSET) | (4<<THEIR_HP_OFFSET);
     s->battle.wobbles = 0;
     s->battle.update_hp = 0;
+    s->battle.user_input = false;
 
     pw_audio_play_sound(SOUND_BATTLE_ENCOUNTER);
 }
@@ -158,11 +159,10 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
         break;
     }
     case BATTLE_APPEARED: {
-        if(s->battle.anim_frame >= 5) {
+        if(s->battle.user_input) {
             pw_battle_switch_substate(s, BATTLE_CHOOSING);
             s->battle.anim_frame = 0;
-        } else {
-            s->battle.anim_frame++;
+            s->battle.user_input = false;
         }
         break;
     }
@@ -264,7 +264,7 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
 
             switch(our_action) {
                 case ACTION_ATTACK:
-                    if (their_action == ACTION_EVADE) {
+                    if(their_action == ACTION_EVADE) {
                         our_hp -= 1;
                         pw_audio_play_sound(SOUND_BATTLE_HIT);
                     } else {
@@ -273,7 +273,7 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
                     }
                     break;
                 case ACTION_EVADE:
-                    if (their_action == ACTION_ATTACK || their_action == ACTION_SPECIAL) {
+                    if(their_action == ACTION_ATTACK || their_action == ACTION_SPECIAL) {
                         pw_audio_play_sound(SOUND_BATTLE_EVADE);
                     }
                     break;
@@ -310,7 +310,7 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
 
             switch(their_action) {
                 case ACTION_ATTACK:
-                    if (our_action == ACTION_EVADE) {
+                    if(our_action == ACTION_EVADE) {
                         their_hp -= 1;
                         pw_audio_play_sound(SOUND_BATTLE_HIT);
                     } else {
@@ -319,12 +319,12 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
                     }
                     break;
                 case ACTION_EVADE:
-                    if (our_action == ACTION_ATTACK) {
+                    if(our_action == ACTION_ATTACK) {
                         pw_audio_play_sound(SOUND_BATTLE_EVADE);
                     }
                     break;
                 case ACTION_SPECIAL:
-                    if (our_action == ACTION_EVADE) {
+                    if(our_action == ACTION_EVADE) {
                         their_hp -= 1;
                         pw_audio_play_sound(SOUND_BATTLE_HIT);
                     } else {
@@ -360,10 +360,7 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
         break;
     }
     case BATTLE_THEY_FLED: {
-        if(s->battle.anim_frame == 3) {
-            pw_audio_play_sound(SOUND_BATTLE_FLED);
-        }
-        if(s->battle.anim_frame >= MESSAGE_DISPLAY_ANIM_LENGTH) {
+        if(s->battle.user_input) {
             event_log_item_t *event_log = (event_log_item_t*)(decompression_buf);
             route_info_t *route_info = (route_info_t*)(decompression_buf + sizeof(event_log_item_t));
             pw_eeprom_read(PW_EEPROM_ADDR_ROUTE_INFO, (uint8_t*)route_info, sizeof(route_info_t));
@@ -482,9 +479,6 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
         break;
     }
     case BATTLE_POKEMON_CAUGHT: {
-        if(s->battle.anim_frame <= MESSAGE_DISPLAY_ANIM_LENGTH) {
-            pw_audio_play_sound(SOUND_BATTLE_CAUGHT);
-        }
         if(s->battle.anim_frame >= MESSAGE_DISPLAY_ANIM_LENGTH) { }
         break;
     }
@@ -605,9 +599,6 @@ void pw_battle_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf
         break;
     }
     case BATTLE_CATCH_STARS: {
-        if (s->battle.anim_frame == 3) {
-            pw_audio_play_sound(SOUND_NAVIGATE_MENU);
-        }
         if(s->battle.anim_frame >= CATCH_ANIM_LENGTH) {
             s->battle.substate_queue_index++;
             s->battle.anim_frame = 0;
@@ -681,12 +672,6 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
         // pw_screen_draw_img(&their_sprite, THEIR_NORMAL_X, THEIR_NORMAL_Y);
         pw_screen_draw_img(&our_sprite, OUR_NORMAL_X, OUR_NORMAL_Y);
 
-        pw_screen_draw_pokemon_name_and_message(
-            PW_EEPROM_ADDR_TEXT_POKEMON_NAMES + s->battle.chosen_pokemon*PW_EEPROM_SIZE_TEXT_POKEMON_NAME,
-            PW_EEPROM_ADDR_TEXT_APPEARED,
-            PW_SCREEN_BLACK
-        );
-
         pw_img_t health_bar = {
             .width=8,
             .height=8,
@@ -699,12 +684,7 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
         };
         pw_eeprom_read(PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP, eeprom_buf, PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP);
 
-        int8_t health = (s->battle.current_hp&THEIR_HP_MASK) >> THEIR_HP_OFFSET;
-        for(int8_t i = 0; i < health; i++) {
-            pw_screen_draw_img(&health_bar, 8*(i+1), 24);
-        }
-
-        health = (s->battle.current_hp&OUR_HP_MASK) >> OUR_HP_OFFSET;
+        int8_t health = (s->battle.current_hp&OUR_HP_MASK) >> OUR_HP_OFFSET;
         for(int8_t i = 0; i < health; i++) {
             pw_screen_draw_img(&health_bar, PW_SCREEN_WIDTH/2 + 8*(i+1), 0);
         }
@@ -984,7 +964,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
     
     uint8_t count = 0;
     pw_img_queue_t queue[5];
-    if (s->battle.current_substate != BATTLE_OPENING) pw_screen_clear_area(0, 0, 96, 32);
+    if(s->battle.current_substate != BATTLE_OPENING) pw_screen_clear_area(0, 0, 96, 32);
     switch(s->battle.current_substate) {
     case BATTLE_OPENING: {
         if(s->battle.anim_frame > 0) s->battle.anim_frame--;
@@ -995,7 +975,28 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         queue[count++] = (pw_img_queue_t){&our_sprite, PW_SCREEN_WIDTH/2+8, 8};
         queue[count++] = (pw_img_queue_t){&their_sprite, POKEMON_ENTER_XS[s->battle.anim_frame], 0};//8, 0};
         pw_screen_draw_queue(queue, count);
-        draw_hp_bars(s);
+
+        if(s->battle.anim_frame == 3) {
+            draw_hp_bars(s);
+            pw_screen_draw_pokemon_name_and_message(
+                PW_EEPROM_ADDR_TEXT_POKEMON_NAMES + s->battle.chosen_pokemon*PW_EEPROM_SIZE_TEXT_POKEMON_NAME,
+                PW_EEPROM_ADDR_TEXT_APPEARED,
+                PW_SCREEN_BLACK
+            );
+            if(sf->frame & ANIM_FRAME_NORMAL_TIME) {
+                pw_screen_draw_from_eeprom(
+                    PW_SCREEN_WIDTH - 9,
+                    PW_SCREEN_HEIGHT - 9,
+                    8, 8,
+                    PW_EEPROM_ADDR_IMG_MORE_MESSAGE,
+                    PW_EEPROM_SIZE_IMG_MORE_MESSAGE,
+                    false
+                );
+            } else {
+                pw_screen_clear_area(PW_SCREEN_WIDTH - 9, PW_SCREEN_HEIGHT - 9, 8, 8);
+            }
+        }
+        if(s->battle.anim_frame < 3) s->battle.anim_frame++;
         break;
     }
     case BATTLE_CHOOSING: {
@@ -1082,6 +1083,21 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         break;
     }
     case BATTLE_THEY_FLED: {
+        if(s->battle.anim_frame == 2) {
+            pw_audio_play_sound(SOUND_BATTLE_FLED);
+        }
+        if(sf->frame&ANIM_FRAME_NORMAL_TIME) {
+            pw_screen_draw_from_eeprom(
+                PW_SCREEN_WIDTH - 9,
+                PW_SCREEN_HEIGHT - 9,
+                8, 8,
+                PW_EEPROM_ADDR_IMG_MORE_MESSAGE,
+                PW_EEPROM_SIZE_IMG_MORE_MESSAGE,
+                false
+            );
+        } else {
+            pw_screen_clear_area(PW_SCREEN_WIDTH - 9, PW_SCREEN_HEIGHT - 9, 8, 8);
+        }
         // TODO: animation
         s->battle.anim_frame++;
         break;
@@ -1171,6 +1187,10 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
     case BATTLE_CATCH_STARS: {
         queue[count++] = (pw_img_queue_t){&our_sprite, THEIR_ATTACK_XS[0][0], 8};
 
+        if(s->battle.anim_frame == 2) {
+            pw_audio_play_sound(SOUND_NAVIGATE_MENU);
+        }
+
         pw_img_t star = {
             .width=8,
             .height=8,
@@ -1204,6 +1224,10 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
     case BATTLE_POKEMON_CAUGHT: {
         queue[count++] = (pw_img_queue_t){&our_sprite, THEIR_ATTACK_XS[0][0], 8};
 
+        if(s->battle.anim_frame == 2) {
+            pw_audio_play_sound(SOUND_BATTLE_CAUGHT);
+        }
+        
         pw_img_t ball = {
             .width=8,
             .height=8,
@@ -1218,6 +1242,18 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         queue[count++] = (pw_img_queue_t){&ball, THEIR_NORMAL_X+8, 16};
         pw_screen_draw_queue(queue, count);
 
+        if(sf->frame&ANIM_FRAME_NORMAL_TIME) {
+            pw_screen_draw_from_eeprom(
+                PW_SCREEN_WIDTH - 9,
+                PW_SCREEN_HEIGHT - 9,
+                8, 8,
+                PW_EEPROM_ADDR_IMG_MORE_MESSAGE,
+                PW_EEPROM_SIZE_IMG_MORE_MESSAGE,
+                false
+            );
+        } else {
+            pw_screen_clear_area(PW_SCREEN_WIDTH - 9, PW_SCREEN_HEIGHT - 9, 8, 8);
+        }
         s->battle.anim_frame++;
         break;
     }
@@ -1238,7 +1274,7 @@ void pw_battle_handle_input(pw_state_t *s, const screen_flags_t *sf, pw_buttons_
     (void)sf;
     switch(s->battle.current_substate) {
     case BATTLE_APPEARED: {
-        pw_battle_switch_substate(s, BATTLE_CHOOSING);
+        s->battle.user_input = true;
         break;
     }
     case BATTLE_CHOOSING: {
@@ -1267,6 +1303,9 @@ void pw_battle_handle_input(pw_state_t *s, const screen_flags_t *sf, pw_buttons_
         break;
     }
     case BATTLE_THEY_FLED:
+        s->battle.user_input = true;
+        break;
+
     case BATTLE_WE_LOST: {
         s->battle.anim_frame = 99; // Make sure to run things before leaving
         //s->battle.current_substate = BATTLE_GO_TO_SPLASH;

--- a/src/apps/app_battle.c
+++ b/src/apps/app_battle.c
@@ -975,8 +975,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
     
     uint8_t count = 0;
     pw_img_queue_t queue[5];
-    pw_screen_clear_area(0, 0, 96, 32);
-    
+    if (s->battle.current_substate != BATTLE_OPENING) pw_screen_clear_area(0, 0, 96, 32);
     switch(s->battle.current_substate) {
     case BATTLE_OPENING: {
         if(s->battle.anim_frame > 0) s->battle.anim_frame--;

--- a/src/apps/app_comms.c
+++ b/src/apps/app_comms.c
@@ -449,6 +449,18 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 pw_comms_init_display(s, sf);
                 s->comms.anim_frame++;
             }
+            if (sf->frame & ANIM_FRAME_NORMAL_TIME) {
+                pw_screen_draw_from_eeprom(
+                    PW_SCREEN_WIDTH - 9,
+                    PW_SCREEN_HEIGHT - 9,
+                    8, 8,
+                    PW_EEPROM_ADDR_IMG_MORE_MESSAGE,
+                    PW_EEPROM_SIZE_IMG_MORE_MESSAGE,
+                    false
+                );
+            } else {
+                pw_screen_clear_area(PW_SCREEN_WIDTH - 9, PW_SCREEN_HEIGHT - 9, 8, 8);
+            }
             break;
         }
         case COMM_SUBSTATE_DISPLAY_WALK_START_ANIMATION: {

--- a/src/apps/app_comms.c
+++ b/src/apps/app_comms.c
@@ -410,6 +410,7 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
         case COMM_SUBSTATE_FINDING_PEER:
         case COMM_SUBSTATE_DETERMINE_ROLE:
         case COMM_SUBSTATE_AWAITING_SLAVE_ACK:
+        case COMM_SUBSTATE_SLAVE_PERFORM_REQUEST:
         case COMM_SUBSTATE_START_PEER_PLAY:
         case COMM_SUBSTATE_PEER_PLAY_ACK:
         case COMM_SUBSTATE_SEND_MASTER_SPRITES:
@@ -668,21 +669,16 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 s->comms.anim_frame++;
             }
 
-            if(sf->frame&ANIM_FRAME_NORMAL_TIME) {
-                pw_img_t img = {
-                    .width=8,
-                    .height=8,
-                    .data=eeprom_buf,
-                    .size=16,
-                    .lookup_table = {
-                        .addr=PW_FLASH_IMG_IR_ACTIVE,
-                        .use_alt=false
-                    }
-                };
-                pw_flash_read(PW_FLASH_IMG_IR_ACTIVE, img.data);
-                pw_screen_draw_img(&img, (PW_SCREEN_WIDTH-8)/2, 0);
+            if(sf->frame & ANIM_FRAME_NORMAL_TIME) {
+                pw_screen_draw_from_eeprom(
+                    (PW_SCREEN_WIDTH-8)/2, 0,
+                    8, 16,
+                    PW_EEPROM_ADDR_IMG_IR_ARCS,
+                    PW_EEPROM_SIZE_IMG_IR_ARCS,
+                    true
+                );
             } else {
-                pw_screen_clear_area((PW_SCREEN_WIDTH-8)/2, 0, 8, 8);
+                pw_screen_clear_area((PW_SCREEN_WIDTH-8)/2, 0, 8, 16);
             }
             break;
         }

--- a/src/apps/app_comms.c
+++ b/src/apps/app_comms.c
@@ -6,6 +6,7 @@
 #include "../states.h"
 #include "../buttons.h"
 #include "../screen.h"
+#include "../audio.h"
 #include "../eeprom_map.h"
 #include "../flash.h"
 #include "../ir/ir.h"
@@ -521,6 +522,7 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                     );
                     pw_screen_draw_message(PW_SCREEN_HEIGHT-16, 13, 16);
                     pw_screen_draw_text_box(0, PW_SCREEN_HEIGHT-32, PW_SCREEN_WIDTH, 32, PW_SCREEN_BLACK);
+                    pw_audio_play_sound(SOUND_BATTLE_CAUGHT);
                     break;
                 }
                 case 9:
@@ -606,6 +608,7 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                     );
                     pw_screen_draw_message(PW_SCREEN_HEIGHT-16, 14, 16); // "has left"
                     pw_screen_draw_text_box(0, PW_SCREEN_HEIGHT-32, PW_SCREEN_WIDTH, 32, PW_SCREEN_BLACK);
+                    pw_audio_play_sound(SOUND_BATTLE_CAUGHT);
                 }
                 default: break;
             }

--- a/src/apps/app_dowsing.c
+++ b/src/apps/app_dowsing.c
@@ -25,6 +25,7 @@ static uint8_t img_buf[128];
 static void check_guess_draw_init(pw_state_t *s, const screen_flags_t *sf);
 //static void replace_item_draw_update(pw_state_t *s, const screen_flags_t *sf);
 static void selected_draw_update(pw_state_t *s, const screen_flags_t *sf);
+static void awaiting_draw_update(pw_state_t *s, const screen_flags_t *sf);
 static void choosing_draw_update(pw_state_t *s, const screen_flags_t *sf);
 static void choosing_draw_init(pw_state_t *s, const screen_flags_t *sf);
 
@@ -54,7 +55,7 @@ state_void_func_t const draw_update_funcs[N_DOWSING_STATES] = {
     [DOWSING_CHECK_GUESS]   = pw_empty_event,
     [DOWSING_GIVE_ITEM]     = pw_empty_event,
     [DOWSING_QUITTING]      = pw_empty_event,
-    [DOWSING_AWAIT_INPUT]   = pw_empty_event,
+    [DOWSING_AWAIT_INPUT]   = awaiting_draw_update,
     [DOWSING_REVEAL_ITEM]   = pw_empty_event,
     [DOWSING_GO_TO_SWITCH]  = pw_empty_event,
 
@@ -125,7 +126,6 @@ void pw_dowsing_init(pw_state_t *s, const screen_flags_t *sf) {
     s->dowsing.choices_remaining = 2; // set tries left
     s->dowsing.user_input = false;
     s->dowsing.bush_shakes = 0;
-
     s->dowsing.current_cursor = s->dowsing.previous_cursor = 0;
     s->dowsing.current_substate = s->dowsing.previous_substate = DOWSING_ENTRY;
 
@@ -251,9 +251,31 @@ static void selected_draw_update(pw_state_t *s, const screen_flags_t *sf) {
     );
     y = (sf->frame&ANIM_FRAME_NORMAL_TIME)?BUSH_HEIGHT:BUSH_HEIGHT+16-2;
     pw_screen_clear_area(16*s->dowsing.current_cursor, y, 16, 2);
+
+    pw_screen_draw_from_eeprom(
+        0, 0,
+        32, 24,
+        PW_EEPROM_ADDR_IMG_ROUTE_LARGE,
+        PW_EEPROM_SIZE_IMG_ROUTE_LARGE,
+        true
+    );
 }
 
-
+static void awaiting_draw_update(pw_state_t *s, const screen_flags_t *sf) {
+    (void)s;
+    if (sf->frame&ANIM_FRAME_NORMAL_TIME) {
+        pw_screen_draw_from_eeprom(
+            PW_SCREEN_WIDTH - 9,
+            PW_SCREEN_HEIGHT - 9,
+            8, 8,
+            PW_EEPROM_ADDR_IMG_MORE_MESSAGE,
+            PW_EEPROM_SIZE_IMG_MORE_MESSAGE,
+            false
+        );
+    } else {
+        pw_screen_clear_area(PW_SCREEN_WIDTH - 9, PW_SCREEN_HEIGHT - 9, 8, 8);
+    }
+}
 /*
 static void replace_item_draw_update(pw_state_t *s, const screen_flags_t *sf) {
     for(uint8_t i = 0; i < 3; i++) {
@@ -323,6 +345,17 @@ static void check_guess_draw_init(pw_state_t *s, const screen_flags_t *sf) {
         PW_EEPROM_SIZE_IMG_CHAR,
         false
     );
+
+    pw_screen_draw_from_eeprom(
+        0, 0,
+        32, 24,
+        PW_EEPROM_ADDR_IMG_ROUTE_LARGE,
+        PW_EEPROM_SIZE_IMG_ROUTE_LARGE,
+        true
+    );
+
+    choosing_draw_update(s, sf);
+
     s->dowsing.current_substate = s->dowsing.current_substate;
 
 }
@@ -416,6 +449,7 @@ void pw_dowsing_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *s
                 s->dowsing.user_input = false;
                 s->dowsing.current_substate = DOWSING_AWAIT_INPUT;
                 s->dowsing.next_substate = DOWSING_INTERMEDIATE;
+                switch_substate(s, DOWSING_AWAIT_INPUT);
             } else {
                 s->dowsing.choices_remaining = 0;  // we got it wrong
                 switch_substate(s, DOWSING_REVEAL_ITEM);
@@ -446,9 +480,10 @@ void pw_dowsing_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *s
             //pw_screen_draw_text_box(0, PW_SCREEN_HEIGHT-16, PW_SCREEN_WIDTH, 16, 0x3);
         }
 
-        s->dowsing.user_input = 0;
+        s->dowsing.user_input = false;
         s->dowsing.current_substate = DOWSING_AWAIT_INPUT;
         s->dowsing.next_substate = DOWSING_CHOOSING;
+        switch_substate(s, DOWSING_AWAIT_INPUT);
         break;
     }
     case DOWSING_GIVE_ITEM: {
@@ -494,7 +529,6 @@ void pw_dowsing_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *s
 
         if( avail >= 3 ) {
             s->dowsing.current_cursor = 0;
-
             s->dowsing.user_input = false;
             s->dowsing.current_substate = DOWSING_AWAIT_INPUT;
             s->dowsing.next_substate = DOWSING_GO_TO_SWITCH;
@@ -517,7 +551,7 @@ void pw_dowsing_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *s
         pw_eeprom_read(PW_EEPROM_ADDR_ROUTE_INFO, (uint8_t*)route_info, sizeof(route_info_t));
         // TODO: Read special route flag
         pw_log_event(event_log, route_info, EVENT_TYPE_ITEM_DOWSED, s->dowsing.chosen_item, false, 0);
-
+        switch_substate(s, DOWSING_AWAIT_INPUT);
         break;
     }
     case DOWSING_REVEAL_ITEM: {
@@ -536,6 +570,7 @@ void pw_dowsing_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *s
             s->dowsing.user_input = false;
             s->dowsing.current_substate = DOWSING_AWAIT_INPUT;
             s->dowsing.next_substate = DOWSING_QUITTING;
+            switch_substate(s, DOWSING_AWAIT_INPUT);
         }
         break;
     }

--- a/src/apps/app_dowsing.c
+++ b/src/apps/app_dowsing.c
@@ -157,7 +157,7 @@ void pw_dowsing_init_display(pw_state_t *s, const screen_flags_t *sf) {
                     8, 8,
                     PW_EEPROM_ADDR_IMG_ARROW_UP_NORMAL,
                     PW_EEPROM_SIZE_IMG_ARROW,
-                    false
+                    true
                 );
             } else {
                 pw_screen_draw_from_eeprom(
@@ -165,7 +165,7 @@ void pw_dowsing_init_display(pw_state_t *s, const screen_flags_t *sf) {
                     8, 8,
                     PW_EEPROM_ADDR_IMG_ARROW_UP_OFFSET,
                     PW_EEPROM_SIZE_IMG_ARROW,
-                    false
+                    true
                 );
             }
         }
@@ -234,7 +234,7 @@ static void choosing_draw_update(pw_state_t *s, const screen_flags_t *sf) {
         8, 8,
         addr,
         PW_EEPROM_SIZE_IMG_ARROW,
-        false
+        true
     );
 
 }
@@ -265,7 +265,7 @@ static void replace_item_draw_update(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_UP_NORMAL,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
     } else {
         pw_screen_draw_from_eeprom(
@@ -273,7 +273,7 @@ static void replace_item_draw_update(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_UP_OFFSET,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
     }
 

--- a/src/apps/app_inventory.c
+++ b/src/apps/app_inventory.c
@@ -5,6 +5,7 @@
 #include "../eeprom.h"
 #include "../eeprom_map.h"
 #include "../screen.h"
+#include "../audio.h"
 #include "../buttons.h"
 #include "../globals.h"
 #include "../types.h"
@@ -118,6 +119,7 @@ void pw_inventory_handle_input(pw_state_t *s, const screen_flags_t *sf, pw_butto
  *  9 = special/gifted item
  */
 static void pw_inventory_move_cursor(pw_state_t *s, int8_t m) {
+    uint8_t old_substate = s->inventory.current_substate;
 
     switch(s->inventory.current_substate) {
     case SUBSCREEN_FOUND: {
@@ -136,10 +138,14 @@ static void pw_inventory_move_cursor(pw_state_t *s, int8_t m) {
             if(gbrief.n_peer_play_items > 0) {
                 s->inventory.current_substate = SUBSCREEN_PRESENTS;  // change to presents screen
                 s->inventory.current_cursor = 0;
+                pw_audio_play_sound(SOUND_CURSOR_MOVE);
             } else {
                 s->inventory.current_cursor = 9;
+                pw_audio_play_sound(SOUND_NAVIGATE_BACK);
                 pw_inventory_move_cursor(s, -1);   // laziest way of setting cursor to last non-empty slot
             }
+        } else if(old_substate == s->inventory.current_substate) {
+            pw_audio_play_sound(SOUND_CURSOR_MOVE);
         }
         break;
     }
@@ -148,9 +154,13 @@ static void pw_inventory_move_cursor(pw_state_t *s, int8_t m) {
         if(s->inventory.current_cursor < 0) {
             s->inventory.current_substate = SUBSCREEN_FOUND;
             s->inventory.current_cursor = 10;
+            pw_audio_play_sound(SOUND_CURSOR_MOVE);
             pw_inventory_move_cursor(s, -1);   // laziest way of setting cursor to last non-empty slot
         } else if(s->inventory.current_cursor >= gbrief.n_peer_play_items) {
             s->inventory.current_cursor = gbrief.n_peer_play_items-1;
+            pw_audio_play_sound(SOUND_NAVIGATE_BACK);
+        } else {
+            pw_audio_play_sound(SOUND_CURSOR_MOVE);
         }
 
         break;
@@ -504,11 +514,13 @@ void pw_inventory_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t 
     switch(s->inventory.current_substate) {
     case SUBSTATE_GO_TO_SPLASH: {
         p->sid = STATE_SPLASH;
+        pw_audio_play_sound(SOUND_NAVIGATE_MENU);
         break;
     }
     case SUBSTATE_GO_TO_MENU: {
         p->sid = STATE_MAIN_MENU;
         p->menu.cursor = 4;
+        pw_audio_play_sound(SOUND_NAVIGATE_BACK);
         break;
     }
     default:

--- a/src/apps/app_inventory.c
+++ b/src/apps/app_inventory.c
@@ -208,7 +208,7 @@ static void draw_cursor(pw_state_t *s, const screen_flags_t *sf) {
         8, 8,
         addr,
         PW_EEPROM_SIZE_IMG_ARROW,
-        false
+        true
     );
 }
 
@@ -308,7 +308,7 @@ static void pw_inventory_draw_screen1(pw_state_t *s, const screen_flags_t *sf) {
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
-        false
+        true
     );
 
     pw_screen_draw_from_eeprom(
@@ -316,7 +316,7 @@ static void pw_inventory_draw_screen1(pw_state_t *s, const screen_flags_t *sf) {
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RIGHT,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT,
-        false
+        true
     );
 
     pw_screen_draw_from_eeprom(
@@ -412,7 +412,7 @@ static void pw_inventory_draw_screen2(pw_state_t *s, const screen_flags_t *sf) {
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_LEFT,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_LEFT,
-        false
+        true
     );
 
     pw_screen_draw_from_eeprom(

--- a/src/apps/app_picowalker.c
+++ b/src/apps/app_picowalker.c
@@ -99,31 +99,25 @@ void pw_picowalker_settings_handle_input(pw_state_t *s, const screen_flags_t *sf
 
 
 static void draw_color_option(pw_screen_pos_t x, pw_screen_pos_t y) {
+    pw_img_t img = (pw_img_t) {
+        .width = 48,
+        .height = 16,
+        .size = 48*16/4,
+        .lookup_table = {
+            .addr=-1,
+            .use_alt=false
+        }
+    };
+
     if(pw_color_mode == (N_COLOR_MODES-1)) {
-        pw_img_t img = (pw_img_t) {
-            .width = 48,
-            .height = 16,
-            .data = color_fancy_text,
-            .size = 48*16/4,
-            .lookup_table = {
-                .addr=-1,
-                .use_alt=false
-            }
-        };
-        pw_screen_draw_img(&img, x, y);
-        x = 56;
-        pw_screen_clear_area(x, y, PW_SCREEN_WIDTH-x, 16);
+        img.data = color_fancy_text;
     } else {
-        pw_img_t img = (pw_img_t) {
-            .width = 48,
-            .height = 16,
-            .data = grey_fancy_text,
-            .size = 48*16/4
-        };
-        pw_screen_draw_img(&img, x, y);
-        x = PW_SCREEN_WIDTH;
-        x = pw_screen_draw_integer(pw_color_mode, x, y);
+        img.data = grey_fancy_text;
     }
+
+    pw_screen_draw_img(&img, x, y);
+    x = PW_SCREEN_WIDTH;
+    x = pw_screen_draw_integer(pw_color_mode, x, y);
 }
 
 void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
@@ -131,6 +125,9 @@ void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf
     (void)sf;
     pw_screen_pos_t x, y;
 
+    s->picowalker.previous_color_mode = pw_color_mode;
+    pw_screen_clear();
+    
     // Title bar
     pw_img_t img = (pw_img_t){
         .width=80,
@@ -186,6 +183,11 @@ void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf
 
 
 void pw_picowalker_settings_update_display(pw_state_t *s, const screen_flags_t *sf) {
+    if(pw_color_mode != s->picowalker.previous_color_mode) {
+        pw_picowalker_settings_init_display(s, sf);
+        return;
+    }
+
     pw_eeprom_addr_t addr = sf->frame&ANIM_FRAME_NORMAL_TIME?PW_EEPROM_ADDR_IMG_ARROW_RIGHT_NORMAL:
                          PW_EEPROM_ADDR_IMG_ARROW_RIGHT_OFFSET;
     pw_screen_draw_from_eeprom(

--- a/src/apps/app_picowalker.c
+++ b/src/apps/app_picowalker.c
@@ -145,7 +145,7 @@ void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
-        false
+        true
     );
 
     draw_color_option(8, 16);
@@ -195,7 +195,7 @@ void pw_picowalker_settings_update_display(pw_state_t *s, const screen_flags_t *
         8, 8,
         addr,
         PW_EEPROM_SIZE_IMG_ARROW,
-        false
+        true
     );
     for(int8_t i = 0; i < N_ENTRIES; i++) {
         if(i == s->picowalker.cursor) continue;

--- a/src/apps/app_poke_radar.c
+++ b/src/apps/app_poke_radar.c
@@ -242,7 +242,7 @@ void pw_poke_radar_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t
     case RADAR_CHOOSING: {
         if(s->radar.invisible_timer <= 0 && s->radar.active_timer <= 0) {
             s->radar.current_substate = RADAR_FAILED;
-	    pw_audio_play_sound(SOUND_MINIGAME_FAIL);
+	    pw_audio_play_sound(SOUND_BATTLE_FLED);
             PW_SET_REQUEST(s->requests, PW_REQUEST_REDRAW);
         }
         break;

--- a/src/apps/app_poke_radar.c
+++ b/src/apps/app_poke_radar.c
@@ -169,6 +169,18 @@ void pw_poke_radar_update_display(pw_state_t *s, const screen_flags_t *sf) {
     }
     case RADAR_FAILED: {
         draw_cursor_update(s, sf);
+        if (sf->frame & ANIM_FRAME_NORMAL_TIME) {
+            pw_screen_draw_from_eeprom(
+                PW_SCREEN_WIDTH - 9,
+                PW_SCREEN_HEIGHT - 9,
+                8, 8,
+                PW_EEPROM_ADDR_IMG_MORE_MESSAGE,
+                PW_EEPROM_SIZE_IMG_MORE_MESSAGE,
+                false
+            );
+        } else {
+            pw_screen_clear_area(PW_SCREEN_WIDTH - 9, PW_SCREEN_HEIGHT - 9, 8, 8);
+        }
         break;
     }
     case RADAR_START_BATTLE: {
@@ -242,7 +254,7 @@ void pw_poke_radar_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t
     case RADAR_CHOOSING: {
         if(s->radar.invisible_timer <= 0 && s->radar.active_timer <= 0) {
             s->radar.current_substate = RADAR_FAILED;
-	    pw_audio_play_sound(SOUND_BATTLE_FLED);
+	        pw_audio_play_sound(SOUND_BATTLE_FLED);
             PW_SET_REQUEST(s->requests, PW_REQUEST_REDRAW);
         }
         break;

--- a/src/apps/app_poke_radar.c
+++ b/src/apps/app_poke_radar.c
@@ -39,7 +39,7 @@ static void draw_cursor_update(pw_state_t *s, const screen_flags_t *sf) {
         8, 8,
         (sf->frame&ANIM_FRAME_NORMAL_TIME)? PW_EEPROM_ADDR_IMG_ARROW_RIGHT_NORMAL:PW_EEPROM_ADDR_IMG_ARROW_RIGHT_OFFSET,
         PW_EEPROM_SIZE_IMG_ARROW,
-        false
+        true
     );
 
     for(uint8_t i = 0; i < 4; i++) {

--- a/src/apps/app_settings.c
+++ b/src/apps/app_settings.c
@@ -103,7 +103,7 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 16,
             PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
             PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
-            false
+            true
         );
         pw_screen_draw_from_eeprom(
             8, 16,
@@ -140,7 +140,7 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_RIGHT_INVERT,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
         pw_screen_draw_from_eeprom(
             8, 40,
@@ -171,7 +171,7 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             addr,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
 
         break;
@@ -182,7 +182,7 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_RIGHT_INVERT,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
         pw_img_t shade_bars = {
             .width=8,
@@ -211,7 +211,7 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             addr,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
 
         pw_screen_pos_t x = 8+N_SHADE_OPTIONS*8;
@@ -240,7 +240,7 @@ void pw_settings_update_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             addr,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
         for(int i = 0; i < N_MAIN_OPTIONS; i++) {
             if(i == s->settings.main_cursor) continue;
@@ -261,7 +261,7 @@ void pw_settings_update_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             addr,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
         for(int i = 0; i < N_SOUND_OPTIONS; i++) {
             if(i == s->settings.sub_cursor) continue;
@@ -280,7 +280,7 @@ void pw_settings_update_display(pw_state_t *s, const screen_flags_t *sf) {
                 8, 8,
                 addr,
                 PW_EEPROM_SIZE_IMG_ARROW,
-                false
+                true
             );
             for(int i = 0; i < N_SHADE_OPTIONS; i++) {
                 if(i == s->settings.sub_cursor) continue;

--- a/src/apps/app_switch.c
+++ b/src/apps/app_switch.c
@@ -6,6 +6,7 @@
 #include "../states.h"
 #include "../eeprom_map.h"
 #include "../screen.h"
+#include "../audio.h"
 #include "../buttons.h"
 #include "../types.h"
 
@@ -167,20 +168,25 @@ void pw_switch_handle_input(pw_state_t *s, const screen_flags_t *sf, pw_buttons_
     case PW_BUTTON_L: {
         if(s->switches.cursor == 0) {
             s->switches.current_substate = SWITCHES_TO_SPLASH;
+            pw_audio_play_sound(SOUND_NAVIGATE_BACK);
             break;
         }
         s->switches.cursor = (s->switches.cursor-1+3)%3;
+        pw_audio_play_sound(SOUND_CURSOR_MOVE);
+        break;
+    }
+    case PW_BUTTON_M: {
+        s->switches.current_substate = SWITCHES_WRITE_INV;
+        pw_audio_play_sound(SOUND_NAVIGATE_MENU);
         break;
     }
     case PW_BUTTON_R: {
         if(s->switches.cursor >= 2) break;
         s->switches.cursor = (s->switches.cursor+1)%3;
+        pw_audio_play_sound(SOUND_CURSOR_MOVE);
         break;
     }
-    case PW_BUTTON_M: {
-        s->switches.current_substate = SWITCHES_WRITE_INV;
-        break;
-    }
+
     }
 
     PW_SET_REQUEST(s->requests, PW_REQUEST_REDRAW);

--- a/src/apps/app_switch.c
+++ b/src/apps/app_switch.c
@@ -75,7 +75,7 @@ void pw_switch_init_display(pw_state_t *s, const screen_flags_t *sf) {
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
-        false
+        true
     );
 
     pw_screen_draw_from_eeprom(
@@ -101,7 +101,7 @@ void pw_switch_init_display(pw_state_t *s, const screen_flags_t *sf) {
         8, 8,
         PW_EEPROM_ADDR_IMG_ARROW_UP_NORMAL,
         PW_EEPROM_SIZE_IMG_ARROW,
-        false
+        true
     );
 }
 
@@ -136,7 +136,7 @@ void pw_switch_update_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_UP_NORMAL,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
     } else {
         pw_screen_draw_from_eeprom(
@@ -144,7 +144,7 @@ void pw_switch_update_display(pw_state_t *s, const screen_flags_t *sf) {
             8, 8,
             PW_EEPROM_ADDR_IMG_ARROW_UP_OFFSET,
             PW_EEPROM_SIZE_IMG_ARROW,
-            false
+            true
         );
     }
 
@@ -154,7 +154,7 @@ void pw_switch_update_display(pw_state_t *s, const screen_flags_t *sf) {
             width, 16,
             addr,
             size,
-            false
+            true
         );
         pw_screen_draw_text_box(0, PW_SCREEN_HEIGHT-16, PW_SCREEN_WIDTH, 16, PW_SCREEN_BLACK);
         s->switches.prev_cursor = s->switches.cursor;

--- a/src/apps/app_trainer_card.c
+++ b/src/apps/app_trainer_card.c
@@ -52,14 +52,14 @@ void pw_trainer_card_init_display(pw_state_t *s, const screen_flags_t *sf) {
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RETURN,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN,
-        false
+        true
     );
     pw_screen_draw_from_eeprom(
         PW_SCREEN_WIDTH-8, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RIGHT,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT,
-        false
+        true
     );
 
     pw_screen_draw_from_eeprom(
@@ -111,7 +111,7 @@ void pw_trainer_card_draw_dayview(uint8_t day, uint32_t day_steps,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_LEFT,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_LEFT,
-        false
+        true
     );
     x+=8;
 
@@ -147,7 +147,7 @@ void pw_trainer_card_draw_dayview(uint8_t day, uint32_t day_steps,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RIGHT,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT,
-        false
+        true
     );
     x+=8;
 

--- a/src/audio.h
+++ b/src/audio.h
@@ -13,10 +13,16 @@
 #define SOUND_POKERADAR_FOUND_STH 3
 #define SOUND_SELECTION_MISS 4
 #define SOUND_DOWSING_FOUND_ITEM 5
-#define SOUND_POKEMON_CAUGHT 7
-#define SOUND_POKEMON_ENCOUNTER 10
-#define SOUND_MINIGAME_FAIL 14
-#define SOUND_POKEBALL_THROW 15
+#define SOUND_BATTLE_UNKNOWN_6          6   // Success Sound?
+#define SOUND_BATTLE_CAUGHT             7
+#define SOUND_BATTLE_UNKNOWN_8          8  // Mono-tone sound . . . . .
+#define SOUND_BATTLE_UNKNOWN_9          9  // Special Sound? 
+#define SOUND_BATTLE_ENCOUNTER          10
+#define SOUND_BATTLE_HIT                11
+#define SOUND_BATTLE_EVADE              12
+#define SOUND_BATTLE_CRITICAL           13
+#define SOUND_BATTLE_FLED               14
+#define SOUND_BATTLE_POKEBALL_THROW     15
 
 
 extern void pw_audio_init();

--- a/src/eeprom_map.h
+++ b/src/eeprom_map.h
@@ -111,10 +111,10 @@
 #define PW_EEPROM_SIZE_IMG_MENU_ARROW_RETURN 32
 //#define PW_EEPROM_ADDR_0x0618 0x0618  // unused
 //#define PW_EEPROM_SIZE_0x0618 40
-#define PW_EEPROM_ADDR_0x0638 0x0638  // symbol for "have more message" in the bottom right of messages. orred into last 8 columns (thus 16 bytes). applied after 0x0648
-#define PW_EEPROM_SIZE_0x0638 16
-#define PW_EEPROM_ADDR_0x0648 0x0648  // symbol for "have more messages" in the bottom right of messages. each byte here is anded with each col of last 8 in the message. both bitplanes (so you can make it black or keep as is). applied before 0x0638
-#define PW_EEPROM_SIZE_0x0648 8
+#define PW_EEPROM_ADDR_IMG_MORE_MESSAGE 0x0638  // symbol for "have more message" in the bottom right of messages. orred into last 8 columns (thus 16 bytes). applied after 0x0648
+#define PW_EEPROM_SIZE_IMG_MORE_MESSAGE 16
+#define PW_EEPROM_ADDR_IMG_MORE_MESSAGES 0x0648  // symbol for "have more messages" in the bottom right of messages. each byte here is anded with each col of last 8 in the message. both bitplanes (so you can make it black or keep as is). applied before 0x0638
+#define PW_EEPROM_SIZE_IMG_MORE_MESSAGES 8
 #define PW_EEPROM_ADDR_0x0650 0x0650  // medicine vial (?) icon 8x8
 #define PW_EEPROM_SIZE_0x0650 16
 #define PW_EEPROM_ADDR_IMG_LOW_BATTERY 0x0660  // low battery icon 8x8

--- a/src/menu.c
+++ b/src/menu.c
@@ -303,7 +303,18 @@ void pw_menu_update_display(pw_state_t *s, const screen_flags_t *sf) {
             pw_eeprom_read(addr, eeprom_buf, PW_EEPROM_SIZE_TEXT_NEED_WATTS);
             pw_screen_overlay_text_box(&img, PW_SCREEN_WIDTH, 16, PW_SCREEN_BLACK);
             pw_screen_draw_img(&img, 0, PW_SCREEN_HEIGHT-16);
-
+            if (sf->frame & ANIM_FRAME_NORMAL_TIME) {
+                pw_screen_draw_from_eeprom(
+                    PW_SCREEN_WIDTH - 9,
+                    PW_SCREEN_HEIGHT - 9,
+                    8, 8,
+                    PW_EEPROM_ADDR_IMG_MORE_MESSAGE,
+                    PW_EEPROM_SIZE_IMG_MORE_MESSAGE,
+                    false
+                );
+            } else {
+                pw_screen_clear_area(PW_SCREEN_WIDTH - 9, PW_SCREEN_HEIGHT - 9, 8, 8);
+            }
             break;
         }
         case MS_CLICKED: { break; }

--- a/src/menu.c
+++ b/src/menu.c
@@ -208,7 +208,7 @@ static void menu_clear_draw_cursor(pw_state_t *s, const screen_flags_t *sf) {
                 8, 8,
                 addr,
                 PW_EEPROM_SIZE_IMG_ARROW,
-                false
+                true
             );
         } else {
             pw_screen_clear_area(4+i*16, CURSOR_Y_VALUES[i]-8, 8, 8);
@@ -231,14 +231,14 @@ void pw_menu_init_display(pw_state_t *s, const screen_flags_t *sf) {
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_LEFT,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_LEFT,
-        false
+        true
     );
     pw_screen_draw_from_eeprom(
         PW_SCREEN_WIDTH-8, 0,
         8, 16,
         PW_EEPROM_ADDR_IMG_MENU_ARROW_RIGHT,
         PW_EEPROM_SIZE_IMG_MENU_ARROW_RIGHT,
-        false
+        true
     );
 
     for(int i = 0; i < MENU_SIZE; i++) {

--- a/src/screen.c
+++ b/src/screen.c
@@ -444,3 +444,11 @@ void pw_screen_overlay_img(pw_img_t *base, pw_img_t *img, pw_screen_pos_t x, pw_
 
 }
 
+/**
+ * Post Processing method for overlaying images.
+ */
+void pw_screen_draw_queue(pw_img_queue_t *queue, uint8_t count){
+    for (uint8_t i =0; i < count; i++) {
+        pw_screen_draw_img(queue[i].img, queue[i].x, queue[i].y);
+    }
+}

--- a/src/screen.h
+++ b/src/screen.h
@@ -11,6 +11,15 @@
 
 #define SCREEN_REDRAW_DELAY_US  250000  // 250ms
 
+/**
+ * An image queue data structure for pokewalker images 
+ * post processing
+ */
+typedef struct pw_img_queue_s {
+    pw_img_t *img;
+    pw_screen_pos_t x;
+    pw_screen_pos_t y;
+} pw_img_queue_t;
 
 /*
  *  Derived functions
@@ -34,7 +43,7 @@ void pw_screen_draw_message_with_text_box(pw_screen_pos_t y, uint8_t message_ind
 void pw_screen_draw_pokemon_name_and_message(pw_eeprom_addr_t poke_addr, pw_eeprom_addr_t message_addr, pw_screen_color_t c);
 void pw_screen_overlay_img(pw_img_t *base, pw_img_t *img, pw_screen_pos_t x, pw_screen_pos_t y);
 void pw_screen_get_blank_image(pw_img_t *img, pw_screen_dim_t w, pw_screen_dim_t h);
-
+void pw_screen_draw_queue(pw_img_queue_t *queue, uint8_t count);
 
 /*
  * Functions defined by the driver

--- a/src/states.h
+++ b/src/states.h
@@ -131,6 +131,7 @@ typedef struct {
     uint8_t substate_queue_len;
     uint8_t wobbles;
     uint8_t update_hp; // bit 0 = ours, bit 1 = theirs
+    bool user_input;
 } app_battle_t;
 
 typedef struct {

--- a/src/states.h
+++ b/src/states.h
@@ -148,6 +148,7 @@ typedef struct {
 typedef struct {
     uint8_t current_substate;
     int8_t cursor;
+    uint8_t previous_color_mode;
 } app_picowalker_t;
 
 typedef struct {


### PR DESCRIPTION
I know we had closed out the issue #9 but it was my mistake for closing it out to earlier since I completely forgot to implement color for the `app battle`. I was able to implement a queue system which 

I am not sure how useful it is to go into detail for each commit but I wanted to explain the intent behind it.

---
- 8a428622ad8409a8cd4ceade7fdc34ef2cfba8d5 - App Battle
  - Implemented full color for the app battle, utilizing a queue (list) system to draw.
- d0049ce9808504a50ac056bab82f063edcda61cd - App Battle
  -  Added sound that was missing from the app battle. I also changed the define variables in `audio.h` I am cool with changing them back. The intent was to keep the sound variables organized where they were commonly used.
- 13d4b7039ddf54a3ab5d8668c23c8eee301896ab - App Poke Radar
  - Name change of the sound define
- 88b2d911445fd11fc82ee254dcb97bb2ae579553 - App Switch
  - Added sound that was missing from the switch `inventory` / `pokemon` screen
- 924787cf860d12b837d44ac683ffd985b94320f3 - App Inventory
  - Added sound that was missing from the app inventory. Included the `end` of the list that has the `SOUND_NAVIGATE_BACK` sound.
- 697993c34e27c410d9e6b3c8fc2ab88ac7630238 - App Battle
  - I accidently introduced a bug from the `BATTLE_OEPNING` when implementing the full color for app battle. This fixes it to allow the opening animation to finish before clearing the screen for the next frame.
- 049ee30da49a39b02b2921b524ad37793f22a99e - App Battle
  - Added the animation of the additional star that was missing when the pokemon was caught.
- ea542be1566219d3ad24645c75c2daf78bfd4e6e - App Battle
  - Attempted to fix the `BATTLE_APPEARED` animation where the pokemon enters in the screen.
- cc1a0997fbf3ad76ffe974ab7ddbc37c19a0a199 - Picowalker Settings
  - Fixed the full screen transition when switching different color palettes.
- cca017bb74ddd52af9a02f98db0d4f8085cbf041 - Feature: Color
  - Changed a lot of the `PW_EEPROM_ADDR_IMG_ARROW` and the menu variants to use the `img.lookup_table.use_alt = true` to support Zenith's colored sprites that were not previously included.
- 47a92c910e080e472955e3c9843ea58139f1dec6 - More Message: App Dowsing
  - Added `PW_EEPROM_ADDR_IMG_MORE_MESSAGE` animation when the user fails dowsing for the item and if there is another try.
  - I have also updated the issue where the bush was clipping into the route image so now I just redrew the route image after the bush does it's animation.
- e073e7cfd1e656890d743c13678304e774681432  - More Message: App Battle
  - Added `...MORE_MESSAGE` animation prompts when the pokemon has fled or when you have caught the pokemon.
  - I have also fixed the `BATTLE_APPEARED` animation for the wild pokemon entering in the screen.
- 962f1826ce8720a186596a2367e224dc9c4402a2 - More Message: App Poke Radar
  - Added `...MORE_MESSAGE` animation prompt when the mini game has failed. 
- 9177e1d5c3ab6ebcd3feccb106a90f27bc46ab7e - More Message: App Comms
  - This was an attempt to get `..MORE_MESSAGE` animation prompt to work but it seems it only worked when there was no receiving packets.
- c7ed599f5775ea41848b55ec56c6f6e1982a470c - App Comms
  - The IR Arcs were not animating at all and it was because it was missing `COMM_SUBSTATE_SLAVE_PERFORM_REQUEST` in the switch case. I also changed the `pw_img_t` to use `pw_screen_draw_from_eeprom()`.
- b3655a8220f31dc136c9a31f2d45ec4bfa31ae16 - App Comms
  - Added the `SOUND_BATTLE_CAUGHT` when the pokemon comes and leaves from the picowalker to match what happens on the pokewalker.
- c43911d0bc66ddde1ca91cf0f7f6f0bccf7fd53f - More Message: Menu
  - When the user has no watts, added the `...MORE_MESSAGE` animation prompt.