### PR TITLE
Feature: Walking Animation

### DIFF
--- a/src/accel.h
+++ b/src/accel.h
@@ -15,9 +15,10 @@ void pw_accel_process_steps();
  */
 
 extern void pw_accel_init();
-extern uint32_t pw_accel_get_new_steps();
 extern void pw_accel_sleep();
 extern void pw_accel_wake();
+extern uint32_t pw_accel_get_new_steps();
+extern uint8_t pw_accel_get_activity();
 
 #endif /* PW_ACCEL_H */
 

--- a/src/apps/app_battle.c
+++ b/src/apps/app_battle.c
@@ -631,6 +631,7 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
         .height=24,
         .data=decompression_buf,
         .size=192,
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=true
@@ -651,6 +652,7 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
         .height=24,
         .data=decompression_buf+192,
         .size=192,
+        .is_flipped=true,
         .lookup_table = {
             .addr=-1,
             .use_alt=true
@@ -677,6 +679,7 @@ void pw_battle_init_display(pw_state_t *s, const screen_flags_t *sf) {
             .height=8,
             .data=eeprom_buf,
             .size=16,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP,
                 .use_alt=true
@@ -834,6 +837,7 @@ static void draw_our_hp_bar(pw_img_t *battle_buffer, uint8_t hp) {
         .height=8,
         .data=decompression_buf,
         .size=PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP,
+        .is_flipped=false,
         .lookup_table = {
             .addr=PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP,
             .use_alt=true
@@ -853,6 +857,7 @@ static void draw_their_hp_bar(pw_img_t *battle_buffer, uint8_t hp) {
         .height=8,
         .data=decompression_buf,
         .size=PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP,
+        .is_flipped=false,
         .lookup_table = {
             .addr=PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP,
             .use_alt=true
@@ -883,6 +888,7 @@ void draw_hp_bars(pw_state_t *s) {
         .height=8,
         .data=decompression_buf,
         .size=PW_EEPROM_SIZE_IMG_RADAR_HP_BLIP,
+        .is_flipped=false,
         .lookup_table = {
             .addr=PW_EEPROM_ADDR_IMG_RADAR_HP_BLIP,
             .use_alt=true
@@ -931,6 +937,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         .height=24,
         .data=eeprom_buf,
         .size=192,
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=true
@@ -950,6 +957,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
         .height=24,
         .data=eeprom_buf+192,
         .size=192,
+        .is_flipped=true,
         .lookup_table = {
             .addr=-1,
             .use_alt=true
@@ -1021,6 +1029,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
                     .height = 32,
                     .data=decompression_buf,
                     .size=PW_EEPROM_SIZE_IMG_RADAR_CRITICAL_HIT,
+                    .is_flipped=false,
                     .lookup_table = {
                         .addr=PW_EEPROM_ADDR_IMG_RADAR_CRITICAL_HIT,
                         .use_alt=true
@@ -1035,6 +1044,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
                     .height = 32,
                     .data=decompression_buf,
                     .size=PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT,
+                    .is_flipped=false,
                     .lookup_table = {
                         .addr=PW_EEPROM_ADDR_IMG_RADAR_ATTACK_HIT,
                         .use_alt=true
@@ -1065,6 +1075,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
                     .height = 32,
                     .data=decompression_buf,
                     .size=PW_EEPROM_SIZE_IMG_RADAR_ATTACK_HIT,
+                    .is_flipped=false,
                     .lookup_table = {
                         .addr=PW_EEPROM_ADDR_IMG_RADAR_ATTACK_HIT,
                         .use_alt=true
@@ -1119,6 +1130,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             .height=8,
             .data=decompression_buf,
             .size=16, 
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_IMG_BALL,
                 .use_alt=true
@@ -1165,6 +1177,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             .height=8,
             .data=decompression_buf,
             .size=16,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_IMG_BALL,
                 .use_alt=true
@@ -1196,6 +1209,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             .height=8,
             .data=decompression_buf,
             .size=16,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_IMG_RADAR_CATCH_EFFECT,
                 .use_alt=true
@@ -1210,6 +1224,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             .height=8,
             .data=decompression_buf,
             .size=16,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_IMG_BALL,
                 .use_alt=true
@@ -1233,6 +1248,7 @@ void pw_battle_update_display(pw_state_t *s, const screen_flags_t *sf) {
             .height=8,
             .data=decompression_buf,
             .size=16,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_IMG_BALL,
                 .use_alt=true

--- a/src/apps/app_comms.c
+++ b/src/apps/app_comms.c
@@ -357,6 +357,7 @@ void pw_comms_init_display(pw_state_t *s, const screen_flags_t *sf) {
                 .height=32, 
                 .data=eeprom_buf,
                 .size=256, 
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=0, // PW_EEPROM_ADDR_IMG_POKEWALKER_BIG, // FLASH_IMG_POKEWALKER
                     .use_alt=true
@@ -370,6 +371,7 @@ void pw_comms_init_display(pw_state_t *s, const screen_flags_t *sf) {
                 .height=8, 
                 .data=eeprom_buf,
                 .size=32, 
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=-1,
                     .use_alt=false
@@ -385,6 +387,7 @@ void pw_comms_init_display(pw_state_t *s, const screen_flags_t *sf) {
                 .height=8,
                 .data=eeprom_buf,
                 .size=32,
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=-1, // FLASH_IMG_FACE_HAPPY,
                     .use_alt=false
@@ -631,6 +634,7 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 .height=8,
                 .data=eeprom_buf,
                 .size=16,
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=PW_FLASH_IMG_UP_ARROW,
                     .use_alt=false
@@ -656,6 +660,7 @@ void pw_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 .height=8,
                 .data=eeprom_buf,
                 .size=32,
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=PW_FLASH_IMG_FACE_SAD,
                     .use_alt=false

--- a/src/apps/app_dowsing.c
+++ b/src/apps/app_dowsing.c
@@ -137,6 +137,7 @@ void pw_dowsing_init_display(pw_state_t *s, const screen_flags_t *sf) {
         .height=16, 
         .data=img_buf,
         .size=PW_EEPROM_SIZE_IMG_DOWSING_BUSH_DARK,
+        .is_flipped=false,
         .lookup_table = {
             .addr=PW_EEPROM_ADDR_IMG_DOWSING_BUSH_DARK,
             .use_alt=true
@@ -507,6 +508,7 @@ void pw_dowsing_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *s
             .height=32,
             .data=eeprom_buf,
             .size=2*PW_EEPROM_SIZE_TEXT_FOUND,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_TEXT_ITEM_NAMES,
                 .use_alt=false

--- a/src/apps/app_first_comms.c
+++ b/src/apps/app_first_comms.c
@@ -97,6 +97,7 @@ void pw_first_comms_init_display(pw_state_t *s, const screen_flags_t *sf) {
         .height=32,
         .data=eeprom_buf,
         .size=256, 
+        .is_flipped=false,
         .lookup_table = {
             .addr=PW_FLASH_IMG_POKEWALKER,
             .use_alt=false
@@ -110,6 +111,7 @@ void pw_first_comms_init_display(pw_state_t *s, const screen_flags_t *sf) {
         .height=8, 
         .data=eeprom_buf,
         .size=32,
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=false
@@ -149,6 +151,7 @@ void pw_first_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 .height=8,
                 .data=eeprom_buf,
                 .size=16,
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=PW_FLASH_IMG_UP_ARROW,
                     .use_alt=false
@@ -166,6 +169,7 @@ void pw_first_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 .height=8, 
                 .data=eeprom_buf,
                 .size=32, 
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=PW_FLASH_IMG_FACE_NEUTRAL,
                     .use_alt=false
@@ -183,6 +187,7 @@ void pw_first_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 .height=8, 
                 .data=eeprom_buf,
                 .size=32, 
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=PW_FLASH_IMG_FACE_SAD,
                     .use_alt=false
@@ -203,6 +208,7 @@ void pw_first_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
             .height=8,
             .data=eeprom_buf,
             .size=32,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_FLASH_IMG_FACE_HAPPY,
                 .use_alt=false
@@ -218,6 +224,7 @@ void pw_first_comms_draw_update(pw_state_t *s, const screen_flags_t *sf) {
                 .height=8,
                 .data=eeprom_buf,
                 .size=16,
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=PW_FLASH_IMG_IR_ACTIVE,
                     .use_alt=false

--- a/src/apps/app_inventory.c
+++ b/src/apps/app_inventory.c
@@ -236,7 +236,7 @@ static void draw_animated_sprite(pw_state_t *s, const screen_flags_t *sf) {
         pw_eeprom_addr_t addr;
         pokemon_summary_t pokemon;
         pokemon_index_t pokemon_index = pw_pokemon_id_to_pokemon_index(gdetailed.entries[s->inventory.current_cursor], &pokemon);
-        pw_pokemon_index_to_small_sprite(pokemon_index, buf, (sf->frame&ANIM_FRAME_NORMAL_TIME)>>ANIM_FRAME_NORMAL_TIME_OFFSET, &addr);
+        pw_pokemon_index_to_small_sprite(pokemon_index, buf, (sf->frame&ANIM_FRAME_DOUBLE_TIME)>>ANIM_FRAME_DOUBLE_TIME_OFFSET, &addr);
         sprite.lookup_table.addr = addr;
         sprite.lookup_table.metadata.pokemon.species = pokemon.le_species;
         sprite.lookup_table.metadata.pokemon.pokemon_flags_1 = pokemon.pokemon_flags_1;

--- a/src/apps/app_inventory.c
+++ b/src/apps/app_inventory.c
@@ -221,6 +221,7 @@ static void draw_animated_sprite(pw_state_t *s, const screen_flags_t *sf) {
         .height=24,
         .data=buf,
         .size=192, // 32*24/4
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=true
@@ -274,6 +275,7 @@ static void draw_name(pw_state_t *s, const screen_flags_t *sf) {
             .height=16,
             .data=buf,
             .size=PW_EEPROM_SIZE_TEXT_POKEMON_NAME,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=-1,
                 .use_alt=false
@@ -288,6 +290,7 @@ static void draw_name(pw_state_t *s, const screen_flags_t *sf) {
             .height=16,
             .data=buf,
             .size=PW_EEPROM_SIZE_TEXT_ITEM_NAME_SINGLE,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=-1,
                 .use_alt=false
@@ -336,6 +339,7 @@ static void pw_inventory_draw_screen1(pw_state_t *s, const screen_flags_t *sf) {
         .height=8,
         .data=buf_pokeball,
         .size=PW_EEPROM_SIZE_IMG_BALL,
+        .is_flipped=false,
         .lookup_table = {
             .addr=PW_EEPROM_ADDR_IMG_BALL,
             .use_alt=true
@@ -348,6 +352,7 @@ static void pw_inventory_draw_screen1(pw_state_t *s, const screen_flags_t *sf) {
         .height=8,
         .data=buf_item,
         .size=PW_EEPROM_SIZE_IMG_ITEM,
+        .is_flipped=false,
         .lookup_table = {
             .addr=PW_EEPROM_ADDR_IMG_ITEM,
             .use_alt=true
@@ -430,6 +435,7 @@ static void pw_inventory_draw_screen2(pw_state_t *s, const screen_flags_t *sf) {
         .height=8,
         .data=buf_item,
         .size=PW_EEPROM_SIZE_IMG_ITEM,
+        .is_flipped=false,
         .lookup_table = {
             .addr=PW_EEPROM_ADDR_IMG_ITEM,
             .use_alt=true

--- a/src/apps/app_picowalker.c
+++ b/src/apps/app_picowalker.c
@@ -103,6 +103,7 @@ static void draw_color_option(pw_screen_pos_t x, pw_screen_pos_t y) {
         .width = 48,
         .height = 16,
         .size = 48*16/4,
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=false
@@ -134,6 +135,7 @@ void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf
         .height=16,
         .data=picowalker_border_text,
         .size=80*16/4,
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=false
@@ -158,6 +160,7 @@ void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf
         .height=16,
         .data=battery_fancy_text,
         .size=32*16/4, // 48*16/4
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=false
@@ -173,6 +176,7 @@ void pw_picowalker_settings_init_display(pw_state_t *s, const screen_flags_t *sf
         .height=16,
         .data=percent_char,
         .size=8*16/4,
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=false
@@ -215,6 +219,7 @@ void pw_picowalker_settings_update_display(pw_state_t *s, const screen_flags_t *
         .height=16,
         .data=battery_fancy_text,
         .size=32*16/4, // 48*16/4
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=false
@@ -230,6 +235,7 @@ void pw_picowalker_settings_update_display(pw_state_t *s, const screen_flags_t *
         .height=16,
         .data=percent_char,
         .size=8*16/4,
+        .is_flipped=false,
         .lookup_table = {
             .addr=-1,
             .use_alt=false

--- a/src/apps/app_poke_radar.c
+++ b/src/apps/app_poke_radar.c
@@ -89,6 +89,7 @@ void pw_poke_radar_init_display(pw_state_t *s, const screen_flags_t *sf) {
             .height=24,
             .data=eeprom_buf,
             .size=192,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_IMG_RADAR_BUSH,
                 .use_alt=true

--- a/src/apps/app_settings.c
+++ b/src/apps/app_settings.c
@@ -125,6 +125,7 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             .height=16,
             .data=picowalker_fancy_text,
             .size=88*16/4,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=-1,
                 .use_alt=false
@@ -189,6 +190,7 @@ void pw_settings_init_display(pw_state_t *s, const screen_flags_t *sf) {
             .height=16,
             .data=eeprom_buf,
             .size=PW_EEPROM_ADDR_IMG_CONTRAST_DEMONSTRATOR,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_IMG_CONTRAST_DEMONSTRATOR,
                 .use_alt=true

--- a/src/apps/app_splash.c
+++ b/src/apps/app_splash.c
@@ -12,12 +12,22 @@
 #include "../types.h"
 #include "../globals.h"
 
+#include "../picowalker_core.h"
+
 /// @file app_splash.c
 
 enum {
     SPLASH_NORMAL,
     SPLASH_GO_TO_MENU,
 };
+
+enum {
+    IDLE,
+    WALKING,
+    STROLLING,
+};
+
+const pw_screen_pos_t origin = 32;
 
 void pw_splash_init(pw_state_t *s, const screen_flags_t *sf) {
     (void)sf;
@@ -52,6 +62,12 @@ void pw_splash_handle_input(pw_state_t *s, const screen_flags_t *sf, pw_buttons_
 }
 
 void pw_splash_init_display(pw_state_t *s, const screen_flags_t *sf) {
+
+    s->splash.walking = IDLE;
+    s->splash.offset = 0;
+    s->splash.anim_frame = 0;
+    s->splash.is_flipped = false;
+
     (void)sf;
     if(s->splash.inventory.caught_pokemon & INV_WALKING_POKEMON) {
         pw_screen_draw_from_eeprom(
@@ -143,16 +159,97 @@ void pw_splash_update_display(pw_state_t *s, const screen_flags_t *sf) {
     }
 
     if(s->splash.inventory.caught_pokemon & INV_WALKING_POKEMON) {
-        pw_screen_draw_from_eeprom(
-            PW_SCREEN_WIDTH-64, 0,
-            64, 48,
-            frame_addr,
-            PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME,
-            true
-        );
 
+        pw_screen_clear_area(32, 0, 64, 48);
+        switch(s->splash.walking) {
+            case IDLE: {
+                pw_screen_draw_from_eeprom(
+                    PW_SCREEN_WIDTH-64, 0,
+                    64, 48,
+                    frame_addr,
+                    PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME,
+                    true
+                );
+                if (pw_is_walking) s->splash.walking = WALKING;
+                break;
+            }
+            case WALKING: {
+                pw_screen_draw_from_eeprom(
+                    origin + s->splash.offset, 0,
+                    64, 48,
+                    frame_addr,
+                    PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME,
+                    true
+                );
+
+                // Move right if still walking, move left if done walking...
+                if (pw_is_walking) {
+                    if (s->splash.offset >= PW_SCREEN_WIDTH - origin) {
+                        s->splash.walking = STROLLING;
+                        s->splash.offset = (PW_SCREEN_WIDTH - origin);
+                    }
+                    else s->splash.offset += 4;
+                }
+                else {
+                    if (s->splash.offset <= 0) {
+                        s->splash.walking = IDLE;
+                        s->splash.offset = 0;
+                    }
+                    else s->splash.offset -= 4;
+                }
+                break;
+            }
+            case STROLLING: {
+                if (pw_is_walking) {
+                    if (s->splash.offset <= 0 && !s->splash.is_flipped) {
+                        s->splash.is_flipped = true;
+                        s->splash.offset = 0;
+                    }
+
+                    if (s->splash.offset >= 32 && s->splash.is_flipped) {
+                        s->splash.is_flipped = false;
+                        s->splash.offset = 32;
+                    }
+
+                    if(sf->frame&ANIM_FRAME_DOUBLE_TIME) {
+                        frame_addr = PW_EEPROM_ADDR_IMG_POKEMON_SMALL_ANIMATED_FRAME1;
+                    } else {
+                        frame_addr = PW_EEPROM_ADDR_IMG_POKEMON_SMALL_ANIMATED_FRAME2;
+                    }
+
+                    pw_img_t img = {
+                        .width=32, 
+                        .height=24,
+                        .data=decompression_buf,
+                        .size=PW_EEPROM_SIZE_IMG_POKEMON_SMALL_ANIMATED_FRAME, 
+                        .is_flipped=s->splash.is_flipped,
+                        .lookup_table = {
+                            .addr=frame_addr,
+                            .use_alt=true
+                        }
+                    };
+                    pw_eeprom_read(frame_addr, img.data, PW_EEPROM_SIZE_IMG_POKEMON_SMALL_ANIMATED_FRAME);
+
+                    pw_screen_draw_img(&img, origin + s->splash.offset, 24);
+                    
+                    if (s->splash.anim_frame >= 3 && s->splash.anim_frame % 2 == 0) {
+                        if (img.is_flipped) s->splash.offset += 4;
+                        else s->splash.offset -= 4;
+                        s->splash.anim_frame = 0;
+                    }
+                    s->splash.anim_frame++;
+                }
+                else {
+                    s->splash.walking = WALKING;
+                    s->splash.offset = (PW_SCREEN_WIDTH - origin);
+                    s->splash.anim_frame = 0;
+                }
+                break;
+            }
+        }
     }
 
+    if (pw_is_walking) pw_accel_process_steps();
     pw_screen_pos_t left_x = pw_screen_draw_integer_with_overline(health_data_cache.today_steps, PW_SCREEN_WIDTH, PW_SCREEN_HEIGHT-16, PW_SCREEN_BLACK);
     pw_screen_draw_horiz_line(0, PW_SCREEN_HEIGHT-16, left_x, PW_SCREEN_BLACK);
 

--- a/src/apps/app_splash.c
+++ b/src/apps/app_splash.c
@@ -10,6 +10,7 @@
 #include "../audio.h"
 #include "../utils.h"
 #include "../types.h"
+#include "../accel.h"
 #include "../globals.h"
 
 #include "../picowalker_core.h"
@@ -160,7 +161,10 @@ void pw_splash_update_display(pw_state_t *s, const screen_flags_t *sf) {
 
     if(s->splash.inventory.caught_pokemon & INV_WALKING_POKEMON) {
 
-        pw_screen_clear_area(32, 0, 64, 48);
+        if (s->splash.walking == WALKING || s->splash.walking == STROLLING) {
+            pw_screen_clear_area(32, 0, 64, 48);
+        }
+
         switch(s->splash.walking) {
             case IDLE: {
                 pw_screen_draw_from_eeprom(
@@ -170,7 +174,7 @@ void pw_splash_update_display(pw_state_t *s, const screen_flags_t *sf) {
                     PW_EEPROM_SIZE_IMG_POKEMON_LARGE_ANIMATED_FRAME,
                     true
                 );
-                if (pw_is_walking) s->splash.walking = WALKING;
+                if (pw_accel_get_activity() != 0) s->splash.walking = WALKING;
                 break;
             }
             case WALKING: {
@@ -183,7 +187,7 @@ void pw_splash_update_display(pw_state_t *s, const screen_flags_t *sf) {
                 );
 
                 // Move right if still walking, move left if done walking...
-                if (pw_is_walking) {
+                if (pw_accel_get_activity() != 0) {
                     if (s->splash.offset >= PW_SCREEN_WIDTH - origin) {
                         s->splash.walking = STROLLING;
                         s->splash.offset = (PW_SCREEN_WIDTH - origin);
@@ -200,7 +204,7 @@ void pw_splash_update_display(pw_state_t *s, const screen_flags_t *sf) {
                 break;
             }
             case STROLLING: {
-                if (pw_is_walking) {
+                if (pw_accel_get_activity() != 0) {
                     if (s->splash.offset <= 0 && !s->splash.is_flipped) {
                         s->splash.is_flipped = true;
                         s->splash.offset = 0;
@@ -249,7 +253,6 @@ void pw_splash_update_display(pw_state_t *s, const screen_flags_t *sf) {
         }
     }
 
-    if (pw_is_walking) pw_accel_process_steps();
     pw_screen_pos_t left_x = pw_screen_draw_integer_with_overline(health_data_cache.today_steps, PW_SCREEN_WIDTH, PW_SCREEN_HEIGHT-16, PW_SCREEN_BLACK);
     pw_screen_draw_horiz_line(0, PW_SCREEN_HEIGHT-16, left_x, PW_SCREEN_BLACK);
 
@@ -258,15 +261,21 @@ void pw_splash_update_display(pw_state_t *s, const screen_flags_t *sf) {
 void pw_splash_event_loop(pw_state_t *s, pw_state_t *p, const screen_flags_t *sf) {
     (void)sf;
     switch(s->splash.current_substate) {
-    case SPLASH_GO_TO_MENU: {
-        p->sid = STATE_MAIN_MENU;
-        p->menu.cursor = s->splash.menu_cursor;
-        break;
-    }
-    default: {
-        // nothing to do
-        break;
-    }
+        case SPLASH_NORMAL: {
+            if((pw_accel_get_activity() != 0) && (sf->frame&ANIM_FRAME_NORMAL_TIME)) {
+                pw_accel_process_steps();
+            }
+            break;
+        }
+        case SPLASH_GO_TO_MENU: {
+            p->sid = STATE_MAIN_MENU;
+            p->menu.cursor = s->splash.menu_cursor;
+            break;
+        }
+        default: {
+            // nothing to do
+            break;
+        }
     }
 }
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -295,6 +295,7 @@ void pw_menu_update_display(pw_state_t *s, const screen_flags_t *sf) {
                 .height=16,
                 .data=eeprom_buf,
                 .size=PW_EEPROM_SIZE_TEXT_NEED_WATTS,
+                .is_flipped=false,
                 .lookup_table = {
                     .addr=addr,
                     .use_alt=false

--- a/src/picowalker.c
+++ b/src/picowalker.c
@@ -30,6 +30,7 @@ pw_state_t a1, a2;
 pw_state_t *current_state = &a1, *pending_state = &a2;
 screen_flags_t screen_flags;
 uint8_t pw_color_mode = 0;
+bool pw_is_walking = false;
 
 void (*pw_current_loop)(void);
 

--- a/src/picowalker_core.h
+++ b/src/picowalker_core.h
@@ -50,6 +50,11 @@ extern int pw_power_get_mode();
 extern uint8_t pw_color_mode;
 
 /**
+ * Walking animation for the splash screen
+ */
+extern bool pw_is_walking;
+
+/**
  * Debug log functions
  */
 #define pw_log_error(s, ...) pw_log_write("[Error] " s __VA_OPT__(,) __VA_ARGS__)

--- a/src/picowalker_core.h
+++ b/src/picowalker_core.h
@@ -50,11 +50,6 @@ extern int pw_power_get_mode();
 extern uint8_t pw_color_mode;
 
 /**
- * Walking animation for the splash screen
- */
-extern bool pw_is_walking;
-
-/**
  * Debug log functions
  */
 #define pw_log_error(s, ...) pw_log_write("[Error] " s __VA_OPT__(,) __VA_ARGS__)

--- a/src/picowalker_structures.h
+++ b/src/picowalker_structures.h
@@ -60,6 +60,7 @@ typedef struct pw_img_s {
     pw_screen_dim_t width, height;
     uint8_t *data;
     size_t size;
+    bool is_flipped: 1;
 
     struct {
         pw_eeprom_addr_t addr;

--- a/src/picowalker_structures.h
+++ b/src/picowalker_structures.h
@@ -176,9 +176,10 @@ typedef enum pw_buttons_e {
  *  Functions defined by driver
  */
 void pw_accel_init();
-uint32_t pw_accel_get_new_steps();
 void pw_accel_sleep();
 void pw_accel_wake();
+uint32_t pw_accel_get_new_steps();
+uint8_t pw_accel_get_activity();
 
 /*
  *  ==================================================================================

--- a/src/screen.c
+++ b/src/screen.c
@@ -18,6 +18,7 @@ void pw_screen_draw_from_eeprom(pw_screen_pos_t x, pw_screen_pos_t y, pw_screen_
         .height=h,
         .data=eeprom_buf,
         .size=len,
+        .is_flipped=false,
         .lookup_table = {
             .addr=addr,
             .use_alt=use_alt
@@ -33,6 +34,7 @@ void pw_screen_draw_from_eeprom_with_text_box(pw_screen_pos_t x, pw_screen_pos_t
         .height=h,
         .data=eeprom_buf,
         .size=len,
+        .is_flipped=false,
         .lookup_table = {
             .addr=addr,
             .use_alt=false
@@ -79,6 +81,7 @@ pw_screen_pos_t pw_screen_draw_integer_with_overline(uint32_t n, pw_screen_pos_t
             .height=16,
             .data=eeprom_buf,
             .size=PW_EEPROM_SIZE_IMG_CHAR,
+            .is_flipped=false,
             .lookup_table = {
                 .addr=PW_EEPROM_ADDR_IMG_DIGITS+PW_EEPROM_SIZE_IMG_CHAR*idx,
                 .use_alt=false
@@ -149,6 +152,7 @@ void pw_screen_draw_message(pw_screen_pos_t y, uint8_t message_index, pw_screen_
         .height=h,
         .data=eeprom_buf,
         .size=sz,
+        .is_flipped=false,
         .lookup_table = {
             .addr=addr,
             .use_alt=false
@@ -174,6 +178,7 @@ void pw_screen_draw_message_with_text_box(pw_screen_pos_t y, uint8_t message_ind
         .height=h,
         .data=eeprom_buf,
         .size=sz,
+        .is_flipped=false,
         .lookup_table = {
             .addr=addr,
             .use_alt=false
@@ -191,6 +196,7 @@ void pw_screen_draw_pokemon_name_and_message(pw_eeprom_addr_t poke_addr, pw_eepr
         .height=32,
         .data=eeprom_buf,
         .size=2*PW_EEPROM_SIZE_TEXT_APPEARED,
+        .is_flipped=false,
         .lookup_table = {
             .addr=poke_addr,
             .use_alt=false

--- a/src/screen.c
+++ b/src/screen.c
@@ -237,9 +237,7 @@ void pw_screen_overlay_text_box(pw_img_t *img, pw_screen_dim_t w, pw_screen_dim_
             for(int j = 2*img->width - 1; j >= 0; j--) {
                 img->data[i*2*w+j] = img->data[i*2*img->width + j];
             }
-            if(i > 0) {
-                memset(&img->data[i*2*img->width], 0, 2*(w-img->width));
-            }
+            memset(&img->data[i*2*w + 2*img->width], 0, 2*(w-img->width));
         }
         img->width = w;
         img->size = img->height * img->width;

--- a/src/states.h
+++ b/src/states.h
@@ -40,6 +40,10 @@ typedef struct {
     pw_brief_inventory_t inventory;
     int8_t menu_cursor;
     uint8_t current_substate;
+    uint8_t walking;
+    uint8_t offset;
+    uint8_t anim_frame;
+    uint8_t is_flipped;
 } app_splash_t;
 
 /*


### PR DESCRIPTION
In regards to https://github.com/mamba2410/picowalker-core/issues/14. I have added the `Walking Animation` for the splash app.

The prerequisite for this to work is we needed a way to flag the driver side to draw the sprites flipped. ~~I hope we don't go further and draw them rotated at 90 degrees~~ The commit 24b1248023f9f12197212f8cb1e83ae5546298e2 added `is_flipped` property for the image.

Once we have the prereq, we can continue with the walking animations 7189ad88420fdab03e4e5d4870ac7eb966f15db6. I kept it simple with 3 states, `IDLE`, `WALKING`, and `STROLLING`. I have also included a starting point `origin` to move the sprites off and on the screen rather than having a `const pw_screen_pos_t array[]` to move the sprites to a fixed position. I think my only concern is the method is not safe *per say*? I did attempt to use an array to move the sprites along but it grew to over 15 values and decided to skip it.

In order for this to all work; I have added 4 variables in states.h `app_splash_t` which are `walking` for the 3 states, `offset` to be used against `origin` the starting point, `anim_frame` to keep track of how many frames have passed before moving the sprites while `STROLLING`, and last, `is_flipped` to update the `img` direction the pokemon should be facing.

I think overall the `core` functionality is working for the walking animations. My driver side of the code could use tweaking but the walking animation is working as long as the `pw_is_walking` is set to true and when it is not true; `STROLLING` stops and switches to `WALKING` and from there the pokemon returns from off the screen back to the `IDLE` state much like the pokewalker.

I noticed in the pokewalker while reviewing the inventory app that the animations seem to be `DOUBLE` than what the splash app is. I've updated the animations to be double f35613d182caed3611045977c289b56c004dc061 and lastly fixed a weird bug I have seen in the overlay text box but it only happens during the inventory app. I have yet to see it anywhere else. aa8ccb7b67611bff10425fef8f4a640fd9fb7bac

Please review, let me know your thoughts and if there are any changes you would like made.